### PR TITLE
Add LICENSE to Manifest.in

### DIFF
--- a/Manifest.in
+++ b/Manifest.in
@@ -1,2 +1,3 @@
 include README.md
+include LICENSE
 recursive-include pyinstrument *.js *.css


### PR DESCRIPTION
Hey-lo,

I've [built a version of `pyinstrument`](https://github.com/conda-forge/pyinstrument-feedstock) using [`conda`](http://conda.pydata.org/) for the [conda-forge](http://conda-forge.github.io/). When possible, we try to include a link to the license file in the `meta.yaml` specification for the build; doing so requires the license be indexed in an explicit [`MANIFEST.in`](https://docs.python.org/2/distutils/sourcedist.html#manifest-related-options) file so that it gets included in the source distribution. This pull should guarantee that the license is included in future source distributions. would you be willing to add it?