### PR TITLE
Make Profiler a context manager

### DIFF
--- a/pyinstrument/profiler.py
+++ b/pyinstrument/profiler.py
@@ -37,6 +37,13 @@ class Profiler(object):
     def stop(self):
         setstatprofile(None)
 
+    def __enter__(self):
+        self.start()
+        return self
+
+    def __exit__(self, *args):
+        self.stop()
+
     def _profile(self, frame, event, arg):
         now = timer()
         time_since_last_signal = now - self.last_profile_time

--- a/test/test_profiler.py
+++ b/test/test_profiler.py
@@ -78,3 +78,12 @@ def test_two_functions():
     assert frame_b.function == 'long_function_b'
     assert 0.2 < frame_a.time() < 0.3
     assert 0.45 < frame_b.time() < 0.55
+
+def test_context_manager():
+    with Profiler() as profiler:
+        long_function_a()
+        long_function_b()
+
+    frame = profiler.first_interesting_frame()
+    assert frame.function == 'test_context_manager'
+    assert len(frame.children) == 2


### PR DESCRIPTION
Rather than have to explicitly start and stop, use Profiler as a context manager to auto-start and stop. Test included.