### PR TITLE
Enable Django versions to work without MiddlewareMixin.

### DIFF
--- a/pyinstrument/middleware.py
+++ b/pyinstrument/middleware.py
@@ -4,7 +4,10 @@ from pyinstrument import Profiler
 from pyinstrument.profiler import NotMainThreadError
 import time
 import os
-from django.utils.deprecation import MiddlewareMixin
+try:
+	from django.utils.deprecation import MiddlewareMixin
+except:
+	import object as MiddlewareMixin
 
 
 class ProfilerMiddleware(MiddlewareMixin):


### PR DESCRIPTION
Hi,

Some of the Django versions don't ship this class. We just decided to get over this problem like so: