### PR TITLE
Fix MiddlewareMixin for older versions of Django

### DIFF
--- a/pyinstrument/middleware.py
+++ b/pyinstrument/middleware.py
@@ -5,9 +5,9 @@ from pyinstrument.profiler import NotMainThreadError
 import time
 import os
 try:
-	from django.utils.deprecation import MiddlewareMixin
-except:
-	import object as MiddlewareMixin
+    from django.utils.deprecation import MiddlewareMixin
+except ImportError:
+    MiddlewareMixin = object
 
 
 class ProfilerMiddleware(MiddlewareMixin):


### PR DESCRIPTION
we can't import `object` as it raises

```
Python 2.7.15 (default, Jun 17 2018, 12:46:58)
[GCC 4.2.1 Compatible Apple LLVM 9.1.0 (clang-902.0.39.2)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import object as test
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ImportError: No module named object
```

Tested with Django 1.9.5