### PR TITLE
Improve messaging around needing to build the Javascript

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,14 @@ Installation
 
 Pyinstrument supports Python 2.7 and 3.3+.
 
+To run pyinstrument from the git repo, you must first run
+
+    python setup.py build
+
+This compiles the Javascript code needed for the HTML output. You will need
+[node](https://nodejs.org/en/) installed. Node is not required for the pip
+install as the framework is already pre-built in the wheel.
+
 How to use it
 -------------
 

--- a/pyinstrument/renderers/html.py
+++ b/pyinstrument/renderers/html.py
@@ -8,6 +8,12 @@ class HTMLRenderer(Renderer):
     def render(self, session):
         resources_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'html_resources/')
 
+        if not os.path.exists(os.path.join(resources_dir, 'app.js')):
+            raise RuntimeError("Could not find app.js. If you are running "
+                               "pyinstrument from a git checkout, run 'python "
+                               "setup.py build' to compile the Javascript "
+                               "(requires nodejs).")
+
         with io.open(os.path.join(resources_dir, 'app.js'), encoding='utf-8') as f:
             js = f.read()
 


### PR DESCRIPTION
I added some text to the README, and a better error message if app.js is not found. 

Fixes #56. 