### PR TITLE
Provide additional arguments in output_text method.

### DIFF
--- a/pyinstrument/profiler.py
+++ b/pyinstrument/profiler.py
@@ -96,8 +96,8 @@ class Profiler(object):
         return call_stack
 
     @deprecated_option('root')
-    def output_text(self, root=None, unicode=False, color=False):
-        return renderers.ConsoleRenderer(unicode=unicode, color=color).render(self.last_session)
+    def output_text(self, root=None, unicode=False, color=False, show_all=False, timeline=False):
+        return renderers.ConsoleRenderer(unicode=unicode, color=color, show_all=show_all, timeline=timeline).render(self.last_session)
 
     @deprecated_option('root')
     def output_html(self, root=None):


### PR DESCRIPTION
Hi,

We use the python profiler in a gunicorn-driven server. It would be nice to still have the possibility to choose between verbose or (the new) compact profiling result text. In case of slow performance we often want to look into the performance of dependencies, because we might have configured them wrong.