### PR TITLE
profiler: remove useless timer check

### DIFF
--- a/pyinstrument/profiler.py
+++ b/pyinstrument/profiler.py
@@ -70,9 +70,6 @@ class Profiler(object):
         now = timer()
         time_since_last_profile = now - self.last_profile_time
 
-        if time_since_last_profile < self.interval:
-            return
-
         if event == 'call':
             frame = frame.f_back
 

--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,7 @@ setup(
     author_email='joerick@mac.com',
     url='https://github.com/joerick/pyinstrument',
     keywords=['profiling', 'profile', 'profiler', 'cpu', 'time', 'sampling'],
-    install_requires=['pyinstrument_cext>=0.2.0'],
+    install_requires=['pyinstrument_cext>=0.2.2'],
     include_package_data=True,
     entry_points={'console_scripts': ['pyinstrument = pyinstrument.__main__:main']},
     zip_safe=False,

--- a/test/test_profiler.py
+++ b/test/test_profiler.py
@@ -59,7 +59,7 @@ def test_profiler_retains_multiple_calls():
 
     frame = profiler.last_session.root_frame()
     assert frame.function == 'test_profiler_retains_multiple_calls'
-    assert len(frame.children) == 5
+    assert len(frame.children) == 4
 
 def test_two_functions():
     profiler = Profiler()
@@ -75,9 +75,9 @@ def test_two_functions():
     frame = profiler.last_session.root_frame()
 
     assert frame.function == 'test_two_functions'
-    assert len(frame.children) == 3
+    assert len(frame.children) == 2
 
-    frame_b, frame_a, _ = sorted(frame.children, key=lambda f: f.time(), reverse=True)
+    frame_b, frame_a = sorted(frame.children, key=lambda f: f.time(), reverse=True)
 
     assert frame_a.function == 'long_function_a'
     assert frame_b.function == 'long_function_b'
@@ -91,7 +91,7 @@ def test_context_manager():
 
     frame = profiler.last_session.root_frame()
     assert frame.function == 'test_context_manager'
-    assert len(frame.children) == 3
+    assert len(frame.children) == 2
 
 def test_json_output():
     with Profiler() as profiler:

--- a/test/test_profiler.py
+++ b/test/test_profiler.py
@@ -59,7 +59,7 @@ def test_profiler_retains_multiple_calls():
 
     frame = profiler.last_session.root_frame()
     assert frame.function == 'test_profiler_retains_multiple_calls'
-    assert len(frame.children) == 4
+    assert len(frame.children) == 5
 
 def test_two_functions():
     profiler = Profiler()
@@ -75,9 +75,9 @@ def test_two_functions():
     frame = profiler.last_session.root_frame()
 
     assert frame.function == 'test_two_functions'
-    assert len(frame.children) == 2
+    assert len(frame.children) == 3
 
-    frame_b, frame_a = sorted(frame.children, key=lambda f: f.time(), reverse=True)
+    frame_b, frame_a, _ = sorted(frame.children, key=lambda f: f.time(), reverse=True)
 
     assert frame_a.function == 'long_function_a'
     assert frame_b.function == 'long_function_b'
@@ -91,7 +91,7 @@ def test_context_manager():
 
     frame = profiler.last_session.root_frame()
     assert frame.function == 'test_context_manager'
-    assert len(frame.children) == 2
+    assert len(frame.children) == 3
 
 def test_json_output():
     with Profiler() as profiler:


### PR DESCRIPTION
The timer check in Profiler.profile ought to be useless since the timing is
already handled by pyinstrument_cext.
In practice, except for rounding errors, time_since_last_profile is always >=
self.interval.