### PR TITLE
Fix Windows filename issue for URLs with a query string

### DIFF
--- a/pyinstrument/middleware.py
+++ b/pyinstrument/middleware.py
@@ -30,7 +30,7 @@ class ProfilerMiddleware(MiddlewareMixin):
 
             # Limit the length of the file name (255 characters is the max limit on major current OS, but it is rather
             # high and the other parts (see line 36) are to be taken into account; so a hundred will be fine here).
-            path = request.get_full_path().replace('/', '_')[:100]
+            path = request.get_full_path().replace('/', '_').replace('?', '_qs_')[:100]
 
             if profile_dir:
                 filename = '{total_time:.3f}s {path} {timestamp:.0f}.html'.format(

--- a/pyinstrument/middleware.py
+++ b/pyinstrument/middleware.py
@@ -30,8 +30,12 @@ class ProfilerMiddleware(MiddlewareMixin):
 
             # Limit the length of the file name (255 characters is the max limit on major current OS, but it is rather
             # high and the other parts (see line 36) are to be taken into account; so a hundred will be fine here).
-            path = request.get_full_path().replace('/', '_').replace('?', '_qs_')[:100]
-
+            path = request.get_full_path().replace('/', '_')[:100]
+            
+            # Swap out ? for _qs_ on Windows, where ? cannot be used in file names.
+            if platform.platform.startswith('Windows'):
+                path = path.replace('?', '_qs_')
+            
             if profile_dir:
                 filename = '{total_time:.3f}s {path} {timestamp:.0f}.html'.format(
                     total_time=request.profiler.root_frame().time(),


### PR DESCRIPTION
Windows doesn't allow "?" in filenames, which causes the pyinstrument Django middleware to fail for any URL with a query string. 

I've added a simple replace of "?" with "_qs_" to the file path, but I'm not sure it's the right approach; query strings can get pretty long, and the resulting var cuts off at 100 chars (which is reasonable). Another approach might be to write the query string into the HTML output, but that's not such a quick pull request 😄