### PR TITLE
Add show callback used for determining whether the profiling page should show or not in Django

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,20 @@ profile something. In this case, add  `PYINSTRUMENT_PROFILE_DIR = 'profiles'`
 to your `settings.py`. Pyinstrument will profile every request and save the
 HTML output to the folder `profiles` in your working directory.
 
+If you want to show the profiling page depending on the request you can define 
+`PYINSTRUMENT_SHOW_CALLBACK` as dotted path to a function used for determining 
+whether the page should show or not.
+You can provide your own function callback(request) which returns True or False 
+in your settings.py.
+
+```python
+def custom_show_pyinstrument(request):
+    return request.user.is_superuser
+
+
+PYINSTRUMENT_SHOW_CALLBACK = "%s.custom_show_pyinstrument" % __name__
+```
+
 ### Profile a web request in Flask
 
 A simple setup to profile a Flask application is the following:

--- a/examples/django_example/django_example/settings.py
+++ b/examples/django_example/django_example/settings.py
@@ -18,16 +18,46 @@ ROOT_URLCONF = 'django_example.urls'
 
 INSTALLED_APPS = (
     'django_example',
+    'django.contrib.admin',
     'django.contrib.contenttypes',
     'django.contrib.auth',
+    'django.contrib.sessions',
+    'django.contrib.messages',
 )
 
-MIDDLEWARE_CLASSES = (
-    'pyinstrument.middleware.ProfilerMiddleware',
+MIDDLEWARE = (
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
+    'pyinstrument.middleware.ProfilerMiddleware',
 )
+
+TEMPLATES = [
+    {
+        'BACKEND': 'django.template.backends.django.DjangoTemplates',
+        'APP_DIRS': True,
+        'OPTIONS': {
+            'context_processors': [
+                'django.template.context_processors.debug',
+                'django.template.context_processors.request',
+                'django.contrib.auth.context_processors.auth',
+                'django.contrib.messages.context_processors.messages',
+                'django.template.context_processors.i18n',
+                'django.template.context_processors.media',
+                'django.template.context_processors.csrf',
+                'django.template.context_processors.tz',
+                'django.template.context_processors.static',
+            ],
+        },
+    },
+]
+
+
+def custom_show_pyinstrument(request):
+    return request.user.is_superuser
+
+
+PYINSTRUMENT_SHOW_CALLBACK = "%s.custom_show_pyinstrument" % __name__

--- a/examples/django_example/django_example/urls.py
+++ b/examples/django_example/django_example/urls.py
@@ -1,6 +1,9 @@
-from django.conf.urls import include, url
+from django.conf.urls import url
+from django.contrib import admin
+
 from . import views
 
 urlpatterns = [
+    url('admin/', admin.site.urls),
     url(r'^$', views.hello_world),
 ]

--- a/pyinstrument/middleware.py
+++ b/pyinstrument/middleware.py
@@ -1,5 +1,6 @@
 from django.http import HttpResponse
 from django.conf import settings
+from django.utils.module_loading import import_string
 from pyinstrument import Profiler
 import sys
 import time
@@ -14,12 +15,21 @@ class ProfilerMiddleware(MiddlewareMixin):
     def process_request(self, request):
         profile_dir = getattr(settings, 'PYINSTRUMENT_PROFILE_DIR', None)
 
-        if getattr(settings, 'PYINSTRUMENT_URL_ARGUMENT', 'profile') in request.GET or profile_dir:
+        func_or_path = getattr(settings, 'PYINSTRUMENT_SHOW_CALLBACK', None)
+        if isinstance(func_or_path, str):
+            show_pyinstrument = import_string(func_or_path)
+        elif callable(func_or_path):
+            show_pyinstrument = func_or_path
+        else:
+            show_pyinstrument = lambda request: True
+
+        if (show_pyinstrument(request) and
+            getattr(settings, 'PYINSTRUMENT_URL_ARGUMENT', 'profile') in request.GET
+        ) or profile_dir:
             profiler = Profiler()
             profiler.start()
 
             request.profiler = profiler
-
 
     def process_response(self, request, response):
         if hasattr(request, 'profiler'):


### PR DESCRIPTION
If you want to show the profiling page depending on the request you can define 
`PYINSTRUMENT_SHOW_CALLBACK` as dotted path to a function used for determining 
whether the page should show or not.
You can provide your own function callback(request) which returns True or False 
in your settings.py.

```python
def custom_show_pyinstrument(request):
    return request.user.is_superuser


PYINSTRUMENT_SHOW_CALLBACK = "%s.custom_show_pyinstrument" % __name__
```