### PR TITLE
turn off root frame assert

### DIFF
--- a/pyinstrument/session.py
+++ b/pyinstrument/session.py
@@ -7,7 +7,7 @@ ASSERTION_MESSAGE = ('Please raise an issue at http://github.com/pyinstrument/is
                      'let me know how you caused this error!')
 
 class ProfilerSession(object):
-    def __init__(self, frame_records, start_time, duration, sample_count, start_call_stack, 
+    def __init__(self, frame_records, start_time, duration, sample_count, start_call_stack,
                  program, cpu_time=None):
         self.frame_records = frame_records
         self.start_time = start_time
@@ -50,7 +50,7 @@ class ProfilerSession(object):
         )
 
     def root_frame(self, trim_stem=True):
-        ''' 
+        '''
         Parses the internal frame records and returns a tree of Frame objects
         '''
         root_frame = None
@@ -71,10 +71,10 @@ class ProfilerSession(object):
                 if stack_depth >= len(frame_stack):
                     frame = Frame(frame_identifier)
                     frame_stack.append(frame)
-                    
+
                     if stack_depth == 0:
                         # There should only be one root frame, as far as I know
-                        assert root_frame is None, ASSERTION_MESSAGE
+#                        assert root_frame is None, ASSERTION_MESSAGE
                         root_frame = frame
                     else:
                         parent = frame_stack[stack_depth-1]
@@ -85,13 +85,13 @@ class ProfilerSession(object):
 
             # assign the time to the final frame
             frame_stack[-1].add_child(SelfTimeFrame(self_time=time))
-        
+
         if root_frame is None:
             return None
-        
+
         if trim_stem:
             root_frame = self._trim_stem(root_frame)
-        
+
         return root_frame
 
     def _trim_stem(self, frame):


### PR DESCRIPTION
related Issue: https://github.com/joerick/pyinstrument/issues/84

I use pyinstrument with similar stack: `gunicorn -k gevent` with `wsgi framework` like `django` and `flask`, and got an `AssertionError`.

Actually, the `root_frame` is not `None`, but after turned off the `Assertion`, I finally got a fine stack tree. So maybe we should remove the assertion here.

( Sorry for my bad English, :) )

```
0.591 profile_fn  wsgi_tracer/tracer.py:13
└─ 0.591 __call__  django/core/handlers/wsgi.py:137
   └─ 0.591 get_response  django/core/handlers/base.py:71
      └─ 0.591 inner  django/core/handlers/exception.py:31
         └─ 0.591 __call__  django/utils/deprecation.py:90
            └─ 0.591 inner  django/core/handlers/exception.py:31
               └─ 0.591 __call__  django/utils/deprecation.py:90
                  └─ 0.591 inner  django/core/handlers/exception.py:31
                     └─ 0.591 __call__  django/utils/deprecation.py:90
                        └─ 0.591 inner  django/core/handlers/exception.py:31
                           └─ 0.591 __call__  django/utils/deprecation.py:90
                              └─ 0.591 inner  django/core/handlers/exception.py:31
                                 └─ 0.591 __call__  django/utils/deprecation.py:90
                                    └─ 0.591 inner  django/core/handlers/exception.py:31
                                       └─ 0.591 __call__  django/utils/deprecation.py:90
                                          └─ 0.591 inner  django/core/handlers/exception.py:31
                                             └─ 0.591 __call__  django/utils/deprecation.py:90
                                                └─ 0.591 inner  django/core/handlers/exception.py:31
                                                   └─ 0.591 _get_response  django/core/handlers/base.py:85
                                                      └─ 0.591 pong  djangoapp/urls.py:23
                                                         ├─ 0.571 sleep  gevent/hub.py:122
                                                         └─ 0.020 __init__  django/http/response.py:288
                                                            └─ 0.020 __init__  django/http/response.py:38
                                                               └─ 0.020 DEFAULT_CONTENT_TYPE  django/conf/__init__.py:118
                                                                  └─ 0.020 extract_stack  traceback.py:200
                                                                     └─ 0.020 extract  traceback.py:321
                                                                        └─ 0.020 line  traceback.py:285
                                                                           └─ 0.020 getline  linecache.py:15
                                                                              └─ 0.020 getlines  linecache.py:37
                                                                                 └─ 0.020 updatecache  linecache.py:82
                                                                                    ├─ 0.013 [self]
                                                                                    └─ 0.007 open  tokenize.py:388
                                                                                       └─ 0.007 detect_encoding  tokenize.py:295
```