### PR TITLE
Add ability to track time spent inside a single level of C functions

### DIFF
--- a/examples/c_sort.py
+++ b/examples/c_sort.py
@@ -1,0 +1,34 @@
+'''
+list.sort is interesting in that it calls a C function, that calls back to a 
+Python function. In an ideal world, we'd be able to record the time inside the
+Python function _inside_ list.sort, but it's not possible currently, due to 
+the way that Python records frame objects. 
+
+Perhaps one day we could add some functionality to pyinstrument_cext to keep 
+a parallel stack containing both C and Python frames. But for now, this is 
+fine.
+'''
+import sys
+import time
+import numpy as np
+
+
+
+arr = np.random.randint(0, 10, 10)
+
+# def print_profiler(frame, event, arg):
+#     if event.startswith('c_'):
+#         print(event, arg, getattr(arg, '__qualname__', arg.__name__), arg.__module__)
+#     else:
+#         print(event, frame.f_code.co_name)
+
+# sys.setprofile(print_profiler)
+
+def slow_key(el):
+    time.sleep(0.01)
+    return 0
+
+for i in range(10):
+    list(arr).sort(key=slow_key)
+
+# sys.setprofile(None)

--- a/examples/np_c_function.py
+++ b/examples/np_c_function.py
@@ -1,0 +1,14 @@
+import sys
+import numpy as np
+
+arr = np.random.randint(0, 10000, 10000)
+
+# def print_profiler(frame, event, arg):
+#     print(event, arg, getattr(arg, '__qualname__', arg.__name__), arg.__module__, dir(arg))
+
+# sys.setprofile(print_profiler)
+
+for i in range(10000):
+        arr.cumsum()
+
+# sys.setprofile(None)

--- a/pyinstrument/profiler.py
+++ b/pyinstrument/profiler.py
@@ -72,8 +72,17 @@ class Profiler(object):
 
         if event == 'call':
             frame = frame.f_back
+        
 
-        self.frame_records.append((self._call_stack_for_frame(frame), time_since_last_profile))
+        call_stack = self._call_stack_for_frame(frame)
+
+        if event == 'c_return' or event == 'c_exception':
+            c_frame_identifier = '%s\x00%s\x00%i' % (
+                getattr(arg, '__qualname__', arg.__name__), '<built-in>', 0
+            )
+            call_stack.append(c_frame_identifier)
+
+        self.frame_records.append((call_stack, time_since_last_profile))
 
         self.last_profile_time = now
 


### PR DESCRIPTION
Sample code:
```python
import sys
import numpy as np

arr = np.random.randint(0, 10000, 10000)

for i in range(10000):
        arr.cumsum()
```

Before:
```
  _     ._   __/__   _ _  _  _ _/_   Recorded: 19:33:38  Samples:  251
 /_//_/// /_\ / //_// / //_'/ //     Duration: 0.262     CPU time: 1.221
/   _/                      v3.1.4

Program: examples/np_c_function.py

0.261 <module>  np_c_function.py:1
├─ 0.175 [self]  
└─ 0.086 <module>  numpy/__init__.py:1
      [114 frames hidden]  numpy, pickle, pathlib, ctypes, ast, ...
```
After:

```
  _     ._   __/__   _ _  _  _ _/_   Recorded: 19:35:01  Samples:  251
 /_//_/// /_\ / //_// / //_'/ //     Duration: 0.264     CPU time: 1.206
/   _/                      v3.1.4

Program: examples/np_c_function.py

0.263 <module>  np_c_function.py:1
├─ 0.172 ndarray.cumsum  <built-in>:0
├─ 0.086 <module>  numpy/__init__.py:1
│     [119 frames hidden]  numpy, pickle, _compat_pickle, re, sr...
│        0.012 <module>  numpy/core/overrides.py:1
│        ├─ 0.007 create_dynamic  <built-in>:0
│        0.003 decorator  numpy/core/overrides.py:166
│        └─ 0.003 compile  <built-in>:0
└─ 0.005 [self] 
```

Fixes the problem reported in #101 