### PR TITLE
docs: fix simple typo, envronment -> environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -480,7 +480,7 @@ This compiles the Javascript code needed for the HTML output. You will need
 [node](https://nodejs.org/en/) installed (Node isn't required for the pip
 install as the Javascript is already pre-built in the wheel).
 
-To setup a dev envronment, do:
+To setup a dev environment, do:
 
     virtualenv --python=python3 env
     . env/bin/activate


### PR DESCRIPTION
There is a small typo in README.md.

Should read `environment` rather than `envronment`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md