### PR TITLE
Update supported Python versions at top of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Installation
 
     pip install pyinstrument
 
-Pyinstrument supports Python 2.7 and 3.3+.
+Pyinstrument supports Python 3.6+.
 
 > To run Pyinstrument from a git checkout, there's a build step.
 Take a look at [Contributing](#contributing) for more info.


### PR DESCRIPTION
The top of the README used to say that 2.7 and 3.3+ are supported. But if you scroll down to the changelog, it mentions dropping support for 3.5... :-) 