### PR TITLE
Bugfix: pass processor_options down to JSONRenderer

### DIFF
--- a/pyinstrument/renderers/html.py
+++ b/pyinstrument/renderers/html.py
@@ -70,6 +70,7 @@ class HTMLRenderer(Renderer):
     def render_json(self, session):
         json_renderer = JSONRenderer()
         json_renderer.processors = self.processors
+        json_renderer.processor_options = self.processor_options
         return json_renderer.render(session)
 
     def default_processors(self):


### PR DESCRIPTION
I was running with `--load-prev` with `-r html` and trying to figure out why `--hide-regex` wasn't doing anything. This is why.