### PR TITLE
Optimize callback routines when the API is available

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -1,0 +1,7 @@
+import nox
+
+
+@nox.session(python=["3.7", "3.8", "3.9"])
+def test(session):
+    session.install("-r", "requirements-dev.txt")
+    session.run("pytest")

--- a/pyinstrument/low_level/stat_profile.c
+++ b/pyinstrument/low_level/stat_profile.c
@@ -273,22 +273,12 @@ call_target(ProfilerState *pState, PyFrameObject *frame, int what, PyObject *arg
 static PyObject *
 call_target(ProfilerState *pState, PyFrameObject *frame, int what, PyObject *arg)
 {
-    PyObject *whatstr;
-    PyObject *result;
-
-    whatstr = whatstrings[what];
-    Py_INCREF(whatstr);
-
     PyFrame_FastToLocals(frame);
-    Py_INCREF(frame);
-
-    PyObject *callargs[4] = { NULL, (PyObject *) frame, whatstr, arg == NULL ? Py_None : arg };
-
-    result = PyObject_Vectorcall(pState->target, callargs + 1, 3 | PY_VECTORCALL_ARGUMENTS_OFFSET, NULL);
+    PyObject *callargs[4] = { NULL, (PyObject *) frame, whatstrings[what], arg == NULL ? Py_None : arg };
+    PyObject *result = PyObject_Vectorcall(pState->target, callargs + 1, 3 | PY_VECTORCALL_ARGUMENTS_OFFSET, NULL);
     PyFrame_LocalsToFast(frame, 1);
     if (result == NULL)
         PyTraceBack_Here(frame);
-
 
     return result;
 }

--- a/pyinstrument/low_level/stat_profile.c
+++ b/pyinstrument/low_level/stat_profile.c
@@ -232,57 +232,26 @@ trace_init(void)
     return 0;
 }
 
-#if PY_VERSION_HEX < 0x03090000
-static PyObject *
-call_target(ProfilerState *pState, PyFrameObject *frame, int what, PyObject *arg)
-{
-    PyObject *args;
-    PyObject *whatstr;
-    PyObject *result;
-
-    if (arg == NULL)
-        arg = Py_None;
-
-    args = PyTuple_New(3);
-    if (args == NULL)
-        return NULL;
-
-    PyFrame_FastToLocals(frame);
-
-    Py_INCREF(frame);
-    whatstr = whatstrings[what];
-    Py_INCREF(whatstr);
-    if (arg == NULL)
-        arg = Py_None;
-    Py_INCREF(arg);
-    PyTuple_SET_ITEM(args, 0, (PyObject *)frame);
-    PyTuple_SET_ITEM(args, 1, whatstr);
-    PyTuple_SET_ITEM(args, 2, arg);
-
-    /* call the Python-level target function */
-    result = PyObject_CallObject(pState->target, args);
-    PyFrame_LocalsToFast(frame, 1);
-    if (result == NULL)
-        PyTraceBack_Here(frame);
-
-    /* cleanup */
-    Py_DECREF(args);
-    return result;
-}
-#else
 static PyObject *
 call_target(ProfilerState *pState, PyFrameObject *frame, int what, PyObject *arg)
 {
     PyFrame_FastToLocals(frame);
+
+#if PYTHON_VERSION_HEX >= 0x03090000
+    // vectorcall implemention could be faster, is available in Python 3.9
     PyObject *callargs[4] = { NULL, (PyObject *) frame, whatstrings[what], arg == NULL ? Py_None : arg };
     PyObject *result = PyObject_Vectorcall(pState->target, callargs + 1, 3 | PY_VECTORCALL_ARGUMENTS_OFFSET, NULL);
+#else
+    PyObject *result = PyObject_CallFunctionObjArgs(pState->target, (PyObject *) frame, whatstrings[what], arg == NULL ? Py_None : arg, NULL);
+#endif
+
     PyFrame_LocalsToFast(frame, 1);
+
     if (result == NULL)
         PyTraceBack_Here(frame);
 
     return result;
 }
-#endif
 
 //////////////////////
 // Public functions //

--- a/pyinstrument/low_level/stat_profile.c
+++ b/pyinstrument/low_level/stat_profile.c
@@ -111,7 +111,7 @@ static int ProfilerState_UpdateContextVar(ProfilerState *self) {
 static double ProfilerState_GetTime(ProfilerState *self) {
     if (self->timer_func != NULL) {
         // when a self->timer_func is set, call that.
-        PyObject *result = PyEval_CallObject(self->timer_func, NULL);
+        PyObject *result = PyObject_CallObject(self->timer_func, NULL);
         if (result == NULL) {
             return -1.0;
         }
@@ -255,7 +255,7 @@ call_target(ProfilerState *pState, PyFrameObject *frame, int what, PyObject *arg
     PyTuple_SET_ITEM(args, 2, arg);
 
     /* call the Python-level target function */
-    result = PyEval_CallObject(pState->target, args);
+    result = PyObject_CallObject(pState->target, args);
 
     PyFrame_LocalsToFast(frame, 1);
     if (result == NULL)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -9,3 +9,4 @@ furo==2021.6.18b36
 sphinxcontrib-programoutput==0.17
 pytest-asyncio==0.12.0  # pinned to an older version due to an incompatibility with flaky
 greenlet  # used by a test
+nox


### PR DESCRIPTION
I noticed some deprecation warnings when building pyinstrument again cpython HEAD, and decided to go all the way and use the new optimized function invocation options available in 3.9, when possible. No idea how much this affects the actual performance.