### PR TITLE
Ensure test/ is not installed in site-packages

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open(os.path.join(os.path.dirname(__file__), "README.md")) as f:
 
 setup(
     name="pyinstrument",
-    packages=find_packages(),
+    packages=find_packages(include=("pyinstrument", "pyinstrument.*")),
     version="4.0.3",
     ext_modules=[
         Extension(

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open(os.path.join(os.path.dirname(__file__), "README.md")) as f:
 
 setup(
     name="pyinstrument",
-    packages=find_packages(include=("pyinstrument", "pyinstrument.*")),
+    packages=find_packages(include=["pyinstrument", "pyinstrument.*"]),
     version="4.0.3",
     ext_modules=[
         Extension(


### PR DESCRIPTION
Fixes:

```
$ python3 -m venv _e
$ . _e/bin/activate
(_e) $ pip install pyinstrument
[…]
Successfully installed pyinstrument-4.0.3
(_e) $ ls _e/lib64/python3.9/site-packages/test/
conftest.py        low_level        test_overflow.py        test_profiler.py       util.py
fake_time_util.py  __pycache__      test_processors.py      test_stack_sampler.py
__init__.py        test_cmdline.py  test_profiler_async.py  test_threading.py
```

An alternative would be to adopt a package layout [with a src/ directory](https://setuptools.pypa.io/en/latest/userguide/package_discovery.html#using-find-namespace-or-find-namespace-packages).