### PR TITLE
Fix typos discovered by codespell

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,6 +19,13 @@ repos:
       - id: black
         language_version: python3
 
+-   repo: https://github.com/codespell-project/codespell
+    rev: v2.1.0
+    hooks:
+      - id: codespell
+        args:
+          - --ignore-words-list=vas --skip="*.js"
+
 -   repo: local
     hooks:
     -   id: pyright

--- a/pyinstrument/low_level/stat_profile.c
+++ b/pyinstrument/low_level/stat_profile.c
@@ -238,7 +238,7 @@ call_target(ProfilerState *pState, PyFrameObject *frame, int what, PyObject *arg
     PyFrame_FastToLocals(frame);
 
 #if PY_VERSION_HEX >= 0x03090000
-    // vectorcall implemention could be faster, is available in Python 3.9
+    // vectorcall implementation could be faster, is available in Python 3.9
     PyObject *callargs[4] = { NULL, (PyObject *) frame, whatstrings[what], arg == NULL ? Py_None : arg };
     PyObject *result = PyObject_Vectorcall(pState->target, callargs + 1, 3 | PY_VECTORCALL_ARGUMENTS_OFFSET, NULL);
 #else

--- a/test/util.py
+++ b/test/util.py
@@ -10,8 +10,8 @@ from pyinstrument.frame import BaseFrame
 from pyinstrument.profiler import Profiler
 
 if "CI" in os.environ:
-    # a decorator that allows some test flakyness in CI environments, presumably
-    # due to contention. Useful for tests that rely on real time measurments.
+    # a decorator that allows some test flakiness in CI environments, presumably
+    # due to contention. Useful for tests that rely on real time measurements.
     flaky_in_ci = flaky(max_runs=5, min_passes=1)
 else:
     flaky_in_ci = lambda a: a


### PR DESCRIPTION
[`codespell --ignore-words-list=vas --skip="*.js"`](https://pypi.org/project/codespell)