### PR TITLE
Add support for IPython/Jupyter notebook magics

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,3 +44,4 @@ jobs:
     - name: Test with pytest
       run: |
         pytest
+        pytest --only-ipython-magic

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -99,7 +99,7 @@ you can profile a line or a cell in IPython or Jupyter.
 
 Example:
 ```python
-%load_ext pyinstrument.magic
+%load_ext pyinstrument
 ```
 
 ```

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -93,6 +93,33 @@ that smaller intervals could affect the performance overhead of profiling.
 save this HTML for later, use
 {meth}`profiler.output_html() <pyinstrument.Profiler.output_html>`.
 
+### Profile code in Jupyter/IPython
+Via [IPython magics](https://ipython.readthedocs.io/en/stable/interactive/magics.html),
+you can profile a line or a cell in IPython or Jupyter.
+
+Example:
+```python
+%load_ext pyinstrument.magic
+```
+
+```
+%%pyinstrument
+def a():
+    b()
+    c()
+def b():
+    d()
+def c():
+    d()
+def d():
+    e()
+def e():
+    time.sleep(1)
+a()
+```
+
+To customize options, see `%%pyinstrument??`.
+
 ### Profile a web request in Django
 
 To profile Django web requests, add

--- a/pyinstrument/__init__.py
+++ b/pyinstrument/__init__.py
@@ -6,3 +6,7 @@ __version__ = "4.0.4"
 
 # enable deprecation warnings
 warnings.filterwarnings("once", ".*", DeprecationWarning, r"pyinstrument\..*")
+
+def load_ipython_extension(ipython):
+    from pyinstrument.magic import PyinstrumentMagic
+    ipython.register_magics(PyinstrumentMagic)

--- a/pyinstrument/__init__.py
+++ b/pyinstrument/__init__.py
@@ -9,6 +9,11 @@ warnings.filterwarnings("once", ".*", DeprecationWarning, r"pyinstrument\..*")
 
 
 def load_ipython_extension(ipython):
+    """
+    This function is called by IPython to load the pyinstrument IPython
+    extension, which is done with the magic command `%load_ext pyinstrument`.
+    """
+
     from pyinstrument.magic import PyinstrumentMagic
 
     ipython.register_magics(PyinstrumentMagic)

--- a/pyinstrument/__init__.py
+++ b/pyinstrument/__init__.py
@@ -7,6 +7,8 @@ __version__ = "4.0.4"
 # enable deprecation warnings
 warnings.filterwarnings("once", ".*", DeprecationWarning, r"pyinstrument\..*")
 
+
 def load_ipython_extension(ipython):
     from pyinstrument.magic import PyinstrumentMagic
+
     ipython.register_magics(PyinstrumentMagic)

--- a/pyinstrument/magic/__init__.py
+++ b/pyinstrument/magic/__init__.py
@@ -1,0 +1,5 @@
+from .magic import PyinstrumentMagic
+
+
+def load_ipython_extension(ipython):
+    ipython.register_magics(PyinstrumentMagic)

--- a/pyinstrument/magic/__init__.py
+++ b/pyinstrument/magic/__init__.py
@@ -1,5 +1,1 @@
 from .magic import PyinstrumentMagic
-
-
-def load_ipython_extension(ipython):
-    ipython.register_magics(PyinstrumentMagic)

--- a/pyinstrument/magic/_utils.py
+++ b/pyinstrument/magic/_utils.py
@@ -1,0 +1,98 @@
+# This file is largely based on https://gist.github.com/Carreau/0f051f57734222da925cd364e59cc17e which is in the public domain
+# This (or something similar) may eventually be moved into IPython
+import ast
+from ast import Assign, Expr, Load, Name, NodeTransformer, Store, parse
+from textwrap import dedent
+
+
+class PrePostAstTransformer(NodeTransformer):
+    """
+    Allow to safely wrap user code with pre/post execution hooks that
+    run just before and just after usercode, __inside__ the execution loop,
+    But still returns the value of the last Expression.
+
+    This might not behave as expected if the user change the InteractiveShell.ast_node_interactivity option.
+
+    This is currently not hygienic and care must be taken to use uncommon names in the pre/post block.
+
+    Assuming the user have
+
+    ```
+    code_block:
+        [with many expressions]
+    last_expression
+    ```
+
+    It will transform it into
+
+    ```
+    try:
+        pre_block
+        code_block:
+            [with many expressions]
+        return_value = last_expression
+    finally:
+        post_block
+    return_value
+    ```
+
+    Thus makind sure that post is always executed even if pre or user code fails.
+    """
+
+    def __init__(self, pre, post):
+        """
+        pre and post are either strings, or ast.Modules object that need to be run just before or after
+        the user code.
+
+        While strings are possible, we suggest using ast.Modules
+        object and mangling the corresponding varaibles names
+        to be invalid python identifiers to avoid name conflicts.
+        """
+        if isinstance(pre, str):
+            pre = parse(pre)
+        if isinstance(post, str):
+            pre = parse(post)
+
+        self.pre = pre.body
+        self.post = post.body
+        self.active = True
+
+    def reset(self):
+
+        self.core = parse(
+            dedent(
+                """
+            try:
+                pass
+            finally:
+                pass
+            """
+            )
+        )
+        self.try_ = self.core.body[0].body = []
+        self.fin = self.core.body[0].finalbody = []
+
+    def visit_Module(self, node):
+        if not self.active:
+            return node
+        self.reset()
+        last = node.body[-1]
+        ret = None
+        if isinstance(last, Expr):
+            node.body.pop()
+            node.body.append(Assign([Name("ast-tmp", ctx=Store())], value=last.value))
+            ret = Expr(value=Name("ast-tmp", ctx=Load()))
+        # self.core.body.insert(0, Assign([Name('_p', ctx=Store())], value=ast.Constant(None) ))
+        if ret:
+            self.core.body.insert(
+                0, Assign([Name("ast-tmp", ctx=Store())], value=ast.Constant(None))
+            )
+        for p in self.pre + node.body:
+            self.try_.append(p)
+        for p in self.post:
+            self.fin.append(p)
+        if ret is not None:
+            self.core.body.append(ret)
+
+        ast.fix_missing_locations(self.core)
+        return self.core

--- a/pyinstrument/magic/_utils.py
+++ b/pyinstrument/magic/_utils.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 # This file is largely based on https://gist.github.com/Carreau/0f051f57734222da925cd364e59cc17e which is in the public domain
 # This (or something similar) may eventually be moved into IPython
 import ast
@@ -36,22 +38,22 @@ class PrePostAstTransformer(NodeTransformer):
     return_value
     ```
 
-    Thus makind sure that post is always executed even if pre or user code fails.
+    Thus making sure that post is always executed even if pre or user code fails.
     """
 
-    def __init__(self, pre, post):
+    def __init__(self, pre: str | ast.Module, post: str | ast.Module):
         """
         pre and post are either strings, or ast.Modules object that need to be run just before or after
         the user code.
 
         While strings are possible, we suggest using ast.Modules
-        object and mangling the corresponding varaibles names
+        object and mangling the corresponding variable names
         to be invalid python identifiers to avoid name conflicts.
         """
         if isinstance(pre, str):
             pre = parse(pre)
         if isinstance(post, str):
-            pre = parse(post)
+            post = parse(post)
 
         self.pre = pre.body
         self.post = post.body
@@ -69,10 +71,10 @@ class PrePostAstTransformer(NodeTransformer):
             """
             )
         )
-        self.try_ = self.core.body[0].body = []
-        self.fin = self.core.body[0].finalbody = []
+        self.try_ = self.core.body[0].body = []  # type: ignore
+        self.fin = self.core.body[0].finalbody = []  # type: ignore
 
-    def visit_Module(self, node):
+    def visit_Module(self, node: ast.Module):
         if not self.active:
             return node
         self.reset()

--- a/pyinstrument/magic/magic.py
+++ b/pyinstrument/magic/magic.py
@@ -109,4 +109,6 @@ class PyinstrumentMagic(Magics):
         as_text = _active_profiler.output_text(timeline=args.timeline)
         # repr_html may be a bit fragile, but it's been stable for a while
         display({"text/html": as_iframe._repr_html_(), "text/plain": as_text}, raw=True)
+
+        assert not _active_profiler.is_running
         _active_profiler = None

--- a/pyinstrument/magic/magic.py
+++ b/pyinstrument/magic/magic.py
@@ -1,0 +1,97 @@
+from __future__ import print_function
+
+import urllib.parse
+
+from .. import Profiler
+from ._utils import PrePostAstTransformer
+from IPython.core.magic import Magics, line_cell_magic, magics_class
+from IPython.core.magic_arguments import argument, magic_arguments, parse_argstring
+from IPython.display import IFrame, display
+from ast import parse
+
+_active_profiler = None
+
+
+def _get_active_profiler():
+    return _active_profiler
+
+
+@magics_class
+class PyinstrumentMagic(Magics):
+    def __init__(self, shell):
+        super().__init__(shell)
+        # This will leak _get_active_profiler into the users space until we can magle it
+        self.pre = parse(
+            "\nfrom pyinstrument.magic.magic import _get_active_profiler; _get_active_profiler().start()\n"
+        )
+        self.post = parse("\n_get_active_profiler().stop()")
+        self._transformer = PrePostAstTransformer(self.pre, self.post)
+
+    @magic_arguments()
+    @argument(
+        "--interval",
+        type=float,
+        default=0.001,
+        help="The minimum time, in seconds, between each stack sample. See: https://pyinstrument.readthedocs.io/en/latest/reference.html#pyinstrument.Profiler.interval",
+    )
+    @argument(
+        "--async_mode",
+        default="enabled",
+        help="Configures how this Profiler tracks time in a program that uses async/await. See: https://pyinstrument.readthedocs.io/en/latest/reference.html#pyinstrument.Profiler.async_mode",
+    )
+    @argument(
+        "--height",
+        "-h",
+        default=600,
+        help="Output height",
+    )
+    @argument(
+        "--timeline",
+        type=bool,
+        default=False,
+        help="Show output timeline view",
+    )
+    @argument(
+        "code",
+        type=str,
+        nargs="*",
+        help="When used as a line magic, the code to profile",
+    )
+    @line_cell_magic
+    def pyinstrument(self, line, cell=None):
+        """
+        Run a cell with the pyinstrument statastical profiler.
+
+        Converts the line/cell's AST to something like:
+            try:
+                profiler.start()
+                run_code
+            finally:
+                profiler.stop()
+            profiler.output_html()
+        """
+        global _active_profiler
+        args = parse_argstring(self.pyinstrument, line)
+        ip = get_ipython()
+        code = cell or line
+
+        # Turn off the last run (e.g. a user interrupted)
+        if _active_profiler and _active_profiler.is_running:
+            _active_profiler.stop()
+        if self._transformer in ip.ast_transformers:
+            ip.ast_transformers.remove(self._transformer)
+
+        _active_profiler = Profiler(interval=args.interval, async_mode=args.async_mode)
+        ip.ast_transformers.append(self._transformer)
+        ip.run_cell(code)
+        ip.ast_transformers.remove(self._transformer)
+
+        html = _get_active_profiler().output_html(timeline=args.timeline)
+        as_iframe = IFrame(
+            src="data:text/html, " + urllib.parse.quote(html),
+            width="100%",
+            height=args.height,
+        )
+        as_text = _get_active_profiler().output_text(timeline=args.timeline)
+        # repr_html may be a bit fragile, but it's been stable for a while
+        display({"text/html": as_iframe._repr_html_(), "text/plain": as_text}, raw=True)

--- a/pyinstrument/magic/magic.py
+++ b/pyinstrument/magic/magic.py
@@ -60,7 +60,7 @@ class PyinstrumentMagic(Magics):
     @line_cell_magic
     def pyinstrument(self, line, cell=None):
         """
-        Run a cell with the pyinstrument statastical profiler.
+        Run a cell with the pyinstrument statistical profiler.
 
         Converts the line/cell's AST to something like:
             try:

--- a/pyinstrument/magic/magic.py
+++ b/pyinstrument/magic/magic.py
@@ -48,7 +48,7 @@ class PyinstrumentMagic(Magics):
     @argument(
         "--height",
         "-h",
-        default=600,
+        default=400,
         help="Output height",
     )
     @argument(
@@ -104,6 +104,7 @@ class PyinstrumentMagic(Magics):
             src="data:text/html, " + urllib.parse.quote(html),
             width="100%",
             height=args.height,
+            extras=['style="resize: vertical"'],
         )
         as_text = _active_profiler.output_text(timeline=args.timeline)
         # repr_html may be a bit fragile, but it's been stable for a while

--- a/pyinstrument/magic/magic.py
+++ b/pyinstrument/magic/magic.py
@@ -1,13 +1,15 @@
 from __future__ import print_function
 
 import urllib.parse
+from ast import parse
 
-from .. import Profiler
-from ._utils import PrePostAstTransformer
+from IPython import get_ipython
 from IPython.core.magic import Magics, line_cell_magic, magics_class
 from IPython.core.magic_arguments import argument, magic_arguments, parse_argstring
 from IPython.display import IFrame, display
-from ast import parse
+
+from .. import Profiler
+from ._utils import PrePostAstTransformer
 
 _active_profiler = None
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -10,3 +10,4 @@ sphinxcontrib-programoutput==0.17
 pytest-asyncio==0.12.0  # pinned to an older version due to an incompatibility with flaky
 greenlet  # used by a test
 nox
+ipython

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,9 @@ setup(
     url="https://github.com/joerick/pyinstrument",
     keywords=["profiling", "profile", "profiler", "cpu", "time", "sampling"],
     install_requires=[],
+    extras_require = {
+        'jupyter': ['ipython']
+    },
     include_package_data=True,
     python_requires=">=3.7",
     entry_points={"console_scripts": ["pyinstrument = pyinstrument.__main__:main"]},

--- a/setup.py
+++ b/setup.py
@@ -23,9 +23,7 @@ setup(
     url="https://github.com/joerick/pyinstrument",
     keywords=["profiling", "profile", "profiler", "cpu", "time", "sampling"],
     install_requires=[],
-    extras_require = {
-        'jupyter': ['ipython']
-    },
+    extras_require={"jupyter": ["ipython"]},
     include_package_data=True,
     python_requires=">=3.7",
     entry_points={"console_scripts": ["pyinstrument = pyinstrument.__main__:main"]},

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -5,6 +5,39 @@ import pytest
 from pyinstrument import stack_sampler
 
 
+def pytest_addoption(parser) -> None:
+    # IPython tests seem to pollute the test environment, so they're run in a
+    # separate process.
+
+    parser.addoption(
+        "--only-ipython-magic",
+        action="store_true",
+        default=False,
+        help="run only ipython magic tests",
+    )
+
+
+def pytest_configure(config):
+    config.addinivalue_line(
+        "markers", "ipythonmagic: test requires --only-ipython-magic flag to run"
+    )
+
+
+def pytest_collection_modifyitems(config, items) -> None:
+    flag_was_passed = config.getoption("--only-ipython-magic")
+
+    skip_not_ipython = pytest.mark.skip(reason="not an ipython test")
+    skip_ipython = pytest.mark.skip(reason="requires --only-ipython-magic option to run")
+
+    for item in items:
+        if "ipythonmagic" in item.keywords:
+            if not flag_was_passed:
+                item.add_marker(skip_ipython)
+        else:
+            if flag_was_passed:
+                item.add_marker(skip_not_ipython)
+
+
 @pytest.fixture(autouse=True)
 def check_sampler_state():
     assert sys.getprofile() is None

--- a/test/test_ipython_magic.py
+++ b/test/test_ipython_magic.py
@@ -1,0 +1,77 @@
+from test.fake_time_util import fake_time
+
+import pytest
+from IPython.utils.io import capture_output as capture_ipython_output
+
+code = """
+import time
+
+def function_a():
+    function_b()
+    function_c()
+
+def function_b():
+    function_d()
+
+def function_c():
+    function_d()
+
+def function_d():
+    function_e()
+
+def function_e():
+    time.sleep(0.1)
+
+function_a()
+"""
+from IPython.testing.globalipapp import start_ipython
+
+# Tests #
+
+
+def test_magics(ip):
+    with fake_time():
+        with capture_ipython_output() as captured:
+            ip.run_cell_magic("pyinstrument", line="", cell=code)
+
+    assert len(captured.outputs) == 1
+    output = captured.outputs[0]
+    assert "text/html" in output.data
+    assert "text/plain" in output.data
+
+    assert "function_a" in output.data["text/html"]
+    assert "<iframe" in output.data["text/html"]
+    assert "function_a" in output.data["text/plain"]
+
+    assert "- 0.100 sleep" in output.data["text/plain"]
+
+    with fake_time():
+        with capture_ipython_output() as captured:
+            # this works because function_a was defined in the previous cell
+            ip.run_line_magic("pyinstrument", line="function_a()")
+
+    assert len(captured.outputs) == 1
+    output = captured.outputs[0]
+
+    assert "function_a" in output.data["text/plain"]
+    assert "- 0.100 sleep" in output.data["text/plain"]
+
+
+def test_magic_empty_line(ip):
+    # check empty line input
+    ip.run_line_magic("pyinstrument", line="")
+
+
+# Utils #
+
+
+@pytest.fixture(scope="module")
+def session_ip():
+    yield start_ipython()
+
+
+@pytest.fixture(scope="function")
+def ip(session_ip):
+    session_ip.run_line_magic(magic_name="load_ext", line="pyinstrument")
+    yield session_ip
+    session_ip.run_line_magic(magic_name="reset", line="-f")

--- a/test/test_overflow.py
+++ b/test/test_overflow.py
@@ -1,3 +1,4 @@
+import faulthandler
 import inspect
 import sys
 import time
@@ -50,7 +51,6 @@ def test_console(deep_profiler_session):
     ConsoleRenderer().render(deep_profiler_session)
 
 
-# html now uses the json renderer, so it's xfail too.
 def test_html(deep_profiler_session):
     HTMLRenderer().render(deep_profiler_session)
 

--- a/test/test_overflow.py
+++ b/test/test_overflow.py
@@ -1,4 +1,3 @@
-import faulthandler
 import inspect
 import sys
 import time

--- a/test/test_overflow.py
+++ b/test/test_overflow.py
@@ -11,7 +11,7 @@ from pyinstrument.renderers import ConsoleRenderer, HTMLRenderer, JSONRenderer
 
 
 def recurse(depth):
-    if depth == 0:
+    if depth <= 0:
         time.sleep(0.1)
         return
 


### PR DESCRIPTION
Example usage (works in ipython/notebook/lab):
```
%load_ext pyinstrument
```

```
%%pyinstrument
def a():
    b()
    c()
def b():
    d()
def c():
    d()
def d():
    e()
def e():
    time.sleep(1)
a()
```
![image](https://user-images.githubusercontent.com/1813603/137225029-5b5ff5ed-ac98-4c33-b62c-add8facae61e.png)

Extra care is taken to not profile jupyter running the code, which
is the majority of the complexity of this commit.

Fixes: #153