### PR TITLE
Add Option to configure renderers in Django settings

### DIFF
--- a/docs/guide.md
+++ b/docs/guide.md
@@ -122,7 +122,7 @@ def custom_show_pyinstrument(request):
 PYINSTRUMENT_SHOW_CALLBACK = "%s.custom_show_pyinstrument" % __name__
 ```
 
-You can configure the profile output type using setting's variable `PYINSTRUMENT_RENDERER`.
+You can configure the profile output type using setting's variable `PYINSTRUMENT_PROFILE_DIR_RENDERER`.
 Default value is `pyinstrument.renderers.HTMLRenderer`. The supported renderers are
 `pyinstrument.renderers.JSONRenderer`, `pyinstrument.renderers.HTMLRenderer`.
 

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -122,6 +122,10 @@ def custom_show_pyinstrument(request):
 PYINSTRUMENT_SHOW_CALLBACK = "%s.custom_show_pyinstrument" % __name__
 ```
 
+You can configure the profile output type using setting's variable `PYINSTRUMENT_RENDERER`.
+Default value is `pyinstrument.renderers.HTMLRenderer`. The supported renderers are
+`pyinstrument.renderers.JSONRenderer`, `pyinstrument.renderers.HTMLRenderer`.
+
 ### Profile a web request in Flask
 
 A simple setup to profile a Flask application is the following:

--- a/pyinstrument/middleware.py
+++ b/pyinstrument/middleware.py
@@ -25,7 +25,6 @@ def get_renderer_and_extension(path):
         except ImportError as exc:
             print("Unable to import the class: %s" % path)
             raise exc
-            sys.exit(-1)
 
     else:
         renderer = HTMLRenderer()

--- a/pyinstrument/middleware.py
+++ b/pyinstrument/middleware.py
@@ -8,8 +8,8 @@ from django.http import HttpResponse
 from django.utils.module_loading import import_string
 
 from pyinstrument import Profiler
-from pyinstrument.renderers.html import HTMLRenderer
 from pyinstrument.renderers import JSONRenderer
+from pyinstrument.renderers.html import HTMLRenderer
 
 try:
     from django.utils.deprecation import MiddlewareMixin
@@ -18,8 +18,7 @@ except ImportError:
 
 
 def get_renderer_and_extension(path):
-    """Return the renderer instance and output file extension.
-    """
+    """Return the renderer instance and output file extension."""
     if path:
         renderer = import_string(path)()
     else:
@@ -58,7 +57,7 @@ class ProfilerMiddleware(MiddlewareMixin):  # type: ignore
         if hasattr(request, "profiler"):
             profile_session = request.profiler.stop()
 
-            configured_renderer = getattr(settings, 'PYINSTRUMENT_RENDERER', None)
+            configured_renderer = getattr(settings, "PYINSTRUMENT_RENDERER", None)
             renderer, ext = get_renderer_and_extension(configured_renderer)
 
             output = renderer.render(profile_session)
@@ -75,10 +74,7 @@ class ProfilerMiddleware(MiddlewareMixin):  # type: ignore
 
             if profile_dir:
                 filename = "{total_time:.3f}s {path} {timestamp:.0f}.{ext}".format(
-                    total_time=profile_session.duration,
-                    path=path,
-                    timestamp=time.time(),
-                    ext=ext
+                    total_time=profile_session.duration, path=path, timestamp=time.time(), ext=ext
                 )
 
                 file_path = os.path.join(profile_dir, filename)

--- a/pyinstrument/middleware.py
+++ b/pyinstrument/middleware.py
@@ -32,7 +32,8 @@ def get_renderer_and_extension(path):
     if isinstance(renderer, Renderer):
         return renderer, renderer.output_file_extension
     else:
-        print("Renderer should subclass: %s" % Renderer)
+        print("Renderer should subclass: %s. Using HTMLRenderer" % Renderer)
+        return HTMLRenderer(), HTMLRenderer.output_file_extension
 
 
 class ProfilerMiddleware(MiddlewareMixin):  # type: ignore

--- a/pyinstrument/renderers/base.py
+++ b/pyinstrument/renderers/base.py
@@ -29,6 +29,10 @@ class Renderer:
     Dictionary containing processor options, passed to each processor.
     """
 
+    output_file_extension: str = "txt"
+    """Renderer output file extension with out dot prefix. The default value is `txt`
+    """
+
     def __init__(
         self,
         show_all: bool = False,

--- a/pyinstrument/renderers/html.py
+++ b/pyinstrument/renderers/html.py
@@ -20,6 +20,8 @@ class HTMLRenderer(Renderer):
     Renders a rich, interactive web page, as a string of HTML.
     """
 
+    output_file_extension = "html"
+
     def __init__(self, **kwargs: Any):
         super().__init__(**kwargs)
 

--- a/pyinstrument/renderers/jsonrenderer.py
+++ b/pyinstrument/renderers/jsonrenderer.py
@@ -25,6 +25,8 @@ class JSONRenderer(Renderer):
     Outputs a tree of JSON, containing processed frames.
     """
 
+    output_file_extension = "json"
+
     def __init__(self, **kwargs: Any):
         super().__init__(**kwargs)
 


### PR DESCRIPTION
## Description

### Why?

- HTMLRenderer is a default renderer for Django App. 
- It'll be useful to support exporting the profile data for various formats to generate alternate visualization graphs like flame graph and use with other applications like speedscope.

### Changes

- Supports a new Django settings variable `PYINSTRUMENT_RENDERER` which takes in the path of the renderer to use.
- The middleware produces the output in the configured path. The file extension can only be `json, HTML, txt` for now. I'm happy to make the extension configurable too.

Let me know If I need to add test cases and modify the docs. 

Thanks.