### PR TITLE
Add speedscope renderer

### DIFF
--- a/docs/guide.md
+++ b/docs/guide.md
@@ -35,8 +35,8 @@ Here are the options you can use:
                             save to <outfile>
       -r RENDERER, --renderer=RENDERER
                             how the report should be rendered. One of: 'text',
-                            'html', 'json', or python import path to a renderer
-                            class
+                            'html', 'json', 'speedscope', or python import path
+                            to a renderer class
       -t, --timeline        render as a timeline - preserve ordering and don't
                             condense repeated calls
       --hide=EXPR           glob-style pattern matching the file paths whose

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -52,6 +52,8 @@ Therefore, rendering can be customised by changing the ``processors`` property. 
 .. autoclass:: pyinstrument.renderers.HTMLRenderer
 
 .. autoclass:: pyinstrument.renderers.JSONRenderer
+
+.. autoclass:: pyinstrument.renderers.SpeedscopeRenderer
 ```
 
 ### Processors

--- a/pyinstrument/__main__.py
+++ b/pyinstrument/__main__.py
@@ -1,3 +1,5 @@
+# coding: utf-8
+
 from __future__ import annotations
 
 import codecs
@@ -82,7 +84,7 @@ def main():
         action="store",
         type="string",
         help=(
-            "how the report should be rendered. One of: 'text', 'html', 'json', or python "
+            "how the report should be rendered. One of: 'text', 'html', 'json', 'speedscope' or python "
             "import path to a renderer class"
         ),
         default="text",
@@ -328,6 +330,8 @@ def get_renderer_class(renderer: str) -> Type[renderers.Renderer]:
         return renderers.HTMLRenderer
     elif renderer == "json":
         return renderers.JSONRenderer
+    elif renderer == "speedscope":
+        return renderers.SpeedscopeRenderer
     else:
         return object_with_import_path(renderer)
 

--- a/pyinstrument/renderers/__init__.py
+++ b/pyinstrument/renderers/__init__.py
@@ -2,3 +2,4 @@ from pyinstrument.renderers.base import Renderer
 from pyinstrument.renderers.console import ConsoleRenderer
 from pyinstrument.renderers.html import HTMLRenderer
 from pyinstrument.renderers.jsonrenderer import JSONRenderer
+from pyinstrument.renderers.speedscope import SpeedscopeRenderer

--- a/pyinstrument/renderers/speedscope.py
+++ b/pyinstrument/renderers/speedscope.py
@@ -205,8 +205,13 @@ class SpeedscopeRenderer(Renderer):
 
         id_: str = time.strftime("%Y-%m-%dT%H-%M-%S", time.localtime(session.start_time))
         name: str = "CPU profile for {} at {}".format(session.program, id_)
+
+        # Use self._event_time instead of session.duration because there can be
+        # inconsistencies between the two numbers; in the test_speedscope_output
+        # test within test_profiler.py, session.duration is (much) less than
+        # self._event_time (by a factor of at least 150).
         sprofile_list: list[SpeedscopeProfile] = [
-            SpeedscopeProfile(name, self.render_frame(frame), session.duration)
+            SpeedscopeProfile(name, self.render_frame(frame), self._event_time)
         ]
 
         # Exploits Python 3.7+ dictionary property of iterating over

--- a/pyinstrument/renderers/speedscope.py
+++ b/pyinstrument/renderers/speedscope.py
@@ -110,10 +110,6 @@ class SpeedscopeRenderer(Renderer):
         information is used to build up the "events" array in
         speedscope-formatted JSON.
 
-        To make recursive construction of the event array easier, the
-        output contains a trailing comma; this trailing comma must be
-        removed in the render method.
-
         This method has two notable side effects:
 
         * it populates the self._frame_to_index dictionary that matches
@@ -130,9 +126,6 @@ class SpeedscopeRenderer(Renderer):
         as many stack frames, which will crash by exceeding the stack
         limit on deep-but-valid call stacks. List comprehensions are
         avoided for similar reasons.
-
-        TODO(oxberry1@llnl.gov): revise this text if the join method works;
-        then there are no trailing commas in output.
         """
 
         # if frame is None, recursion bottoms out; no event frames

--- a/pyinstrument/renderers/speedscope.py
+++ b/pyinstrument/renderers/speedscope.py
@@ -234,30 +234,6 @@ class SpeedscopeRenderer(Renderer):
         property_decls.append('"profiles": [%s]' %
                               json.dumps(sprofile, cls=SpeedscopeProfileEncoder))
 
-        # # Fields for profile
-        # profile_decls: list[str] = []
-        # profile_type: str = "evented"
-        # profile_decls.append('"type": %s' % encode_str(profile_type))
-
-        # profile_name: str = session.program
-        # profile_decls.append('"name": %s' % encode_str(profile_name))
-
-        # unit: str = "seconds"
-        # profile_decls.append('"unit": %s' % encode_str(unit))
-
-        # start_value: float = 0.0
-        # profile_decls.append('"startValue": %f' % start_value)
-
-        # end_value: float = session.duration
-        # profile_decls.append('"endValue": %f' % end_value)
-
-        # # use render_frame to build up dictionary of frames for 'shared' field
-        # # via the self._frame_to_index field; have it output the string
-        # # representation of the events array
-        # profile_decls.append('"events": [%s]' % self.render_frame(frame))
-        # profile_string = "{%s}" % ",".join(profile_decls)
-
-        # property_decls.append('"profiles": [%s]' % profile_string)
 
         # exploits Python 3.7+ dictionary property of iterating over
         # keys in insertion order

--- a/pyinstrument/renderers/speedscope.py
+++ b/pyinstrument/renderers/speedscope.py
@@ -103,9 +103,9 @@ class SpeedscopeRenderer(Renderer):
     def __init__(self, **kwargs: Any):
         super().__init__(**kwargs)
 
-        # Running wall clock time total, required for speedscope
-        # evented profiles
-        self._total_time: float = 0.0
+        # Member holding a running total of wall clock time needed to
+        # compute the times at which events occur
+        self._event_time: float = 0.0
 
         # Map of speedscope frames to speedscope frame indices, needed
         # to construct evented speedscope profiles; exploits LIFO
@@ -153,7 +153,7 @@ class SpeedscopeRenderer(Renderer):
         sframe_index = self._frame_to_index[sframe]
         open_event = SpeedscopeEvent(
             SpeedscopeEventType.OPEN,
-            self._total_time,
+            self._event_time,
             sframe_index
         )
 
@@ -176,11 +176,11 @@ class SpeedscopeRenderer(Renderer):
         # variant also adds a branch & swap for each summand. Pairwise
         # summation isn't an option here because a running total is
         # needed.
-        self._total_time += frame.self_time
+        self._event_time += frame.self_time
 
         close_event = SpeedscopeEvent(
             SpeedscopeEventType.CLOSE,
-            self._total_time,
+            self._event_time,
             sframe_index
         )
         event_array.append(encode_speedscope_event(close_event))

--- a/pyinstrument/renderers/speedscope.py
+++ b/pyinstrument/renderers/speedscope.py
@@ -203,9 +203,8 @@ class SpeedscopeRenderer(Renderer):
         # Exploits Python 3.7+ dictionary property of iterating over
         # keys in insertion order to build the list of speedscope
         # frames.
-        sframe_list: list[SpeedscopeFrame] = []
-        for sframe in iter(self._frame_to_index):
-            sframe_list.append(sframe)
+        sframe_list: list[SpeedscopeFrame] = [
+            sframe for sframe in iter(self._frame_to_index)]
 
         id_: str = time.strftime("%Y-%m-%dT%H-%M-%S", time.localtime(session.start_time))
         name: str = "CPU profile for {} at {}".format(session.program, id_)

--- a/pyinstrument/renderers/speedscope.py
+++ b/pyinstrument/renderers/speedscope.py
@@ -45,17 +45,6 @@ class SpeedscopeFrameEncoder(json.JSONEncoder):
         return json.JSONEncoder.default(self, obj)
 
 
-def encode_speedscope_frame(sframe: SpeedscopeFrame) -> str:
-    """Returns a string encoding a SpeedscopeFrame as a JSON object."""
-
-    property_decls: list[str] = []
-    property_decls.append('"name": %s' % encode_str(sframe.name))
-    property_decls.append('"file": %s' % encode_str(sframe.file))
-    property_decls.append('"line": %d' % sframe.line)
-
-    return "{%s}" % ",".join(property_decls)
-
-
 class SpeedscopeEventType(Enum):
     """Enum representing the only two types of speedscope frame events"""
     OPEN: str = "O"

--- a/pyinstrument/renderers/speedscope.py
+++ b/pyinstrument/renderers/speedscope.py
@@ -45,10 +45,10 @@ def encode_speedscope_frame(sframe: SpeedscopeFrame) -> str:
     return "{%s}" % ",".join(property_decls)
 
 
-# class SpeedscopeEventType(Enum):
-#     """Enum representing two types of speedscope frame events"""
-#     OPEN: str = "O"
-#     CLOSE: str = "C"
+class SpeedscopeEventType(Enum):
+    """Enum representing the only two types of speedscope frame events"""
+    OPEN: str = "O"
+    CLOSE: str = "C"
 
 # Named tuple to store Speedscope event data
 SpeedscopeEvent: NamedTuple = namedtuple(
@@ -60,7 +60,7 @@ def encode_speedscope_event(event: SpeedscopeEvent) -> str:
     """Returns a string encoding a SpeedscopeEvent as a JSON object."""
 
     property_decls: list[str] = []
-    property_decls.append('"type": %s' % encode_str(event.type))
+    property_decls.append('"type": %s' % encode_str(event.type.value))
     property_decls.append('"at": %f' % event.at)
     property_decls.append('"frame": %d' % event.frame)
 
@@ -140,7 +140,7 @@ class SpeedscopeRenderer(Renderer):
 
         sframe_index = self._frame_to_index[sframe]
         open_event = SpeedscopeEvent(
-            "O", #SpeedscopeEventType.OPEN,
+            SpeedscopeEventType.OPEN,
             self._total_time,
             sframe_index
         )
@@ -167,7 +167,7 @@ class SpeedscopeRenderer(Renderer):
         self._total_time += frame.self_time
 
         close_event = SpeedscopeEvent(
-            "C", # SpeedscopeEventType.CLOSED
+            SpeedscopeEventType.CLOSE,
             self._total_time,
             sframe_index
         )

--- a/pyinstrument/renderers/speedscope.py
+++ b/pyinstrument/renderers/speedscope.py
@@ -241,7 +241,7 @@ class SpeedscopeRenderer(Renderer):
         # keys in insertion order
         shared_decls: list[str] = []
         for sframe in iter(self._frame_to_index):
-            shared_decls.append(encode_speedscope_frame(sframe))
+            shared_decls.append(json.dumps(sframe, cls=SpeedscopeFrameEncoder))
         property_decls.append('"shared": {"frames": [%s]}' % ",".join(shared_decls))
 
         return "{%s}\n" % ",".join(property_decls)

--- a/pyinstrument/renderers/speedscope.py
+++ b/pyinstrument/renderers/speedscope.py
@@ -50,11 +50,17 @@ class SpeedscopeEventType(Enum):
     OPEN: str = "O"
     CLOSE: str = "C"
 
-# Named tuple to store Speedscope event data
-SpeedscopeEvent: NamedTuple = namedtuple(
-    "SpeedscopeEvent",
-    ("type", "at", "frame")
-)
+
+class SpeedscopeEvent(NamedTuple):
+    """
+    Named tuple to store speedscope's concept of an "event", which
+    corresponds to opening or closing stack frames as functions or
+    methods are entered or exited.
+    """
+    type: SpeedscopeEventType
+    at: float
+    frame: int
+
 
 def encode_speedscope_event(event: SpeedscopeEvent) -> str:
     """Returns a string encoding a SpeedscopeEvent as a JSON object."""

--- a/pyinstrument/renderers/speedscope.py
+++ b/pyinstrument/renderers/speedscope.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
 import json
-from typing import Any, Callable
+import time
+from typing import Any, Callable, NamedTuple
+from collections import namedtuple
+from enum import Enum
 
 from pyinstrument import processors
 from pyinstrument.frame import BaseFrame
@@ -19,56 +22,212 @@ encode_str: Callable[[str], str] = json.encoder.encode_basestring  # type: ignor
 def encode_bool(a_bool: bool):
     return "true" if a_bool else "false"
 
+# Named tuple to store data needed for speedscope's concept of a
+# frame, hereafter referred to as a "speedscope frame", as opposed to
+# a "pyinstrument frame". This type must be hashable in order to use
+# it as a dictionary key; a dictionary will be used to track unique
+# speedscope frames.
+SpeedscopeFrame: NamedTuple = namedtuple(
+    "SpeedscopeFrame",
+    ("name", "file", "line")
+)
+
+def encode_speedscope_frame(sframe: SpeedscopeFrame) -> str:
+    """Returns a string encoding a SpeedscopeFrame as a JSON object."""
+
+    property_decls: list[str] = []
+    property_decls.append('"name": %s' % encode_str(sframe.name))
+    property_decls.append('"file": %s' % encode_str(sframe.file))
+    property_decls.append('"line": %d' % sframe.line)
+
+    return "{%s}" % ",".join(property_decls)
+
+
+# class SpeedscopeEventType(Enum):
+#     """Enum representing two types of speedscope frame events"""
+#     OPEN: str = "O"
+#     CLOSE: str = "C"
+
+# Named tuple to store Speedscope event data
+SpeedscopeEvent: NamedTuple = namedtuple(
+    "SpeedscopeEvent",
+    ("type", "at", "frame")
+)
+
+def encode_speedscope_event(event: SpeedscopeEvent) -> str:
+    """Returns a string encoding a SpeedscopeEvent as a JSON object."""
+
+    property_decls: list[str] = []
+    property_decls.append('"type": %s' % encode_str(event.type))
+    property_decls.append('"at": %f' % event.at)
+    property_decls.append('"frame": %d' % event.frame)
+
+    return "{%s}" % ",".join(property_decls)
+
+# Dictionaries in Python 3.7+ track insertion order, and
+# dict.popitem() returns (key, value) pair in reverse insertion order
+# (LIFO)
 
 class SpeedscopeRenderer(Renderer):
     """
-    Outputs a tree of JSON, containing processed frames.
+    Outputs a tree of JSON conforming to the speedscope schema documented at
+
+    wiki: https://github.com/jlfwong/speedscope/wiki/Importing-from-custom-sources
+    schema: https://www.speedscope.app/file-format-schema.json
+    spec: https://github.com/jlfwong/speedscope/blob/main/src/lib/file-format-spec.ts
+    example: https://github.com/jlfwong/speedscope/blob/main/sample/profiles/speedscope/0.0.1/simple.speedscope.json
+
     """
 
     def __init__(self, **kwargs: Any):
         super().__init__(**kwargs)
 
-    def render_frame(self, frame: BaseFrame | None):
-        if frame is None:
-            return "null"
-        # we don't use the json module because it uses 2x stack frames, so
-        # crashes on deep but valid call stacks
+        # Running wall clock time total, required for speedscope
+        # evented profiles
+        self._total_time: float = 0.0
 
-        property_decls: list[str] = []
-        property_decls.append('"function": %s' % encode_str(frame.function or ""))
-        property_decls.append('"file_path_short": %s' % encode_str(frame.file_path_short or ""))
-        property_decls.append('"file_path": %s' % encode_str(frame.file_path or ""))
-        property_decls.append('"line_no": %d' % frame.line_no)
-        property_decls.append('"time": %f' % frame.time())
-        property_decls.append('"await_time": %f' % frame.await_time())
-        property_decls.append(
-            '"is_application_code": %s' % encode_bool(frame.is_application_code or False)
+        # Map of speedscope frames to speedscope frame indices, needed
+        # to construct evented speedscope profiles; exploits LIFO
+        # property of popinfo method in Python 3.7+ dictionaries. This
+        # dictionary is used to build up the "shared" JSON array in
+        # speedscope's schema.
+        self._frame_to_index: dict[SpeedscopeFrame, int] = {}
+
+
+    def render_frame(self, frame: BaseFrame | None):
+        """Renders frame as string by representing it JSON array-formatted
+        string containing the speedscope open frame event, opend and
+        close frame events of all children, and close event, in order,
+        except for the outer enclosing square brackets. This
+        information is used to build up the "events" array in
+        speedscope-formatted JSON.
+
+        To make recursive construction of the event array easier, the
+        output contains a trailing comma; this trailing comma must be
+        removed in the render method.
+
+        This method has two notable side effects:
+
+        * it populates the self._frame_to_index dictionary that matches
+          speedscope frames with their positions in the "shared" array of
+          speedscope output; this dictionary will be used to write this
+          "shared" array in the render method
+
+        * it accumulates a running total of time elapsed by
+          accumulating the self_time spent in each pyinstrument frame;
+          this running total is used by speedscope events to construct
+          a flame chart
+
+        This method avoids using the json module because it uses twice
+        as many stack frames, which will crash by exceeding the stack
+        limit on deep-but-valid call stacks. List comprehensions are
+        avoided for similar reasons.
+
+        TODO(oxberry1@llnl.gov): revise this text if the join method works;
+        then there are no trailing commas in output.
+        """
+
+        # if frame is None, recursion bottoms out; no event frames
+        # need to be added
+        if frame is None:
+            return ""
+
+        sframe = SpeedscopeFrame(frame.function, frame.file_path, frame.line_no)
+        if sframe not in self._frame_to_index:
+            self._frame_to_index[sframe] = len(self._frame_to_index)
+
+        sframe_index = self._frame_to_index[sframe]
+        open_event = SpeedscopeEvent(
+            "O", #SpeedscopeEventType.OPEN,
+            self._total_time,
+            sframe_index
         )
 
-        # can't use list comprehension here because it uses two stack frames each time.
-        children_jsons: list[str] = []
+        event_array: list[str] = [encode_speedscope_event(open_event)]
+
         for child in frame.children:
-            children_jsons.append(self.render_frame(child))
-        property_decls.append('"children": [%s]' % ",".join(children_jsons))
+            child_events = self.render_frame(child)
+            if child_events:
+                event_array.append(child_events)
 
-        if frame.group:
-            property_decls.append('"group_id": %s' % encode_str(frame.group.id))
 
-        return "{%s}" % ",".join(property_decls)
+        # If number of frames approaches 1e16 * desired accuracy
+        # level, consider using Neumaier-Kahan summation; improves
+        # worst-case relative accuracy of sum from O(num_summands *
+        # eps) to (2 * eps + O(num_summands * eps * eps)), where eps
+        # is IEEE-754 double precision unit roundoff, approximately
+        # 1e-16. Average case relative accuracy expressions replace
+        # num_summands with sqrt(num_summands). However, Kahan
+        # summation quadruples operation count of sum, and Neumaier
+        # variant also adds a branch & swap for each summand. Pairwise
+        # summation isn't an option here because a running total is
+        # needed.
+        self._total_time += frame.self_time
+
+        close_event = SpeedscopeEvent(
+            "C", # SpeedscopeEventType.CLOSED
+            self._total_time,
+            sframe_index
+        )
+        event_array.append(encode_speedscope_event(close_event))
+
+        # Omit enclosing square brackets here; these brackets are applied in
+        # the render method
+        return "%s" % ",".join(event_array)
 
     def render(self, session: Session):
         frame = self.preprocess(session.root_frame())
 
         property_decls: list[str] = []
-        property_decls.append('"start_time": %f' % session.start_time)
-        property_decls.append('"duration": %f' % session.duration)
-        property_decls.append('"sample_count": %d' % session.sample_count)
-        property_decls.append('"program": %s' % encode_str(session.program))
-        if session.cpu_time is None:
-            property_decls.append('"cpu_time": null')
-        else:
-            property_decls.append('"cpu_time": %f' % session.cpu_time)
-        property_decls.append('"root_frame": %s' % self.render_frame(frame))
+
+        # Fields for file
+        schema_url: str = "https://www.speedscope.app/file-format-schema.json"
+        property_decls.append('"$schema": %s' % encode_str(schema_url))
+
+        id_: str = time.strftime("%Y-%m-%dT%H-%M-%S", time.localtime(session.start_time))
+        name: str = "CPU profile for {} at {}".format(session.program, id_)
+        property_decls.append('"name": %s' % encode_str(name))
+
+        property_decls.append('"activeProfileIndex": null')
+
+        # TODO(goxberry@gmail.com): figure out how to get version from
+        # pyinstrument and add it here as something like
+        # pyinstrument@4.0.4 ; can't use from pyinstrument import
+        # __version__
+        exporter: str = "pyinstrument"
+        property_decls.append('"exporter": %s' % encode_str(exporter))
+
+        # Fields for profile
+        profile_decls: list[str] = []
+        profile_type: str = "evented"
+        profile_decls.append('"type": %s' % encode_str(profile_type))
+
+        profile_name: str = session.program
+        profile_decls.append('"name": %s' % encode_str(session.program))
+
+        unit: str = "seconds"
+        profile_decls.append('"unit": %s' % encode_str(unit))
+
+        start_value: float = 0.0
+        profile_decls.append('"startValue": %f' % start_value)
+
+        end_value: float = session.duration
+        profile_decls.append('"endValue": %f' % end_value)
+
+        # use render_frame to build up dictionary of frames for 'shared' field
+        # via the self._frame_to_index field; have it output the string
+        # representation of the events array
+        profile_decls.append('"events": [%s]' % self.render_frame(frame))
+        profile_string = "{%s}" % ",".join(profile_decls)
+
+        property_decls.append('"profiles": [%s]' % profile_string)
+
+        # exploits Python 3.7+ dictionary property of iterating over
+        # keys in insertion order
+        shared_decls: list[str] = []
+        for sframe in iter(self._frame_to_index):
+            shared_decls.append(encode_speedscope_frame(sframe))
+        property_decls.append('"shared": {"frames": [%s]}' % ",".join(shared_decls))
 
         return "{%s}\n" % ",".join(property_decls)
 

--- a/pyinstrument/renderers/speedscope.py
+++ b/pyinstrument/renderers/speedscope.py
@@ -2,7 +2,8 @@ from __future__ import annotations
 
 import json
 import time
-from typing import Any, Callable, NamedTuple
+from dataclasses import dataclass
+from typing import Any, Callable
 from enum import Enum
 
 from pyinstrument import processors
@@ -19,10 +20,10 @@ encode_str: Callable[[str], str] = json.encoder.encode_basestring  # type: ignor
 def encode_bool(a_bool: bool):
     return "true" if a_bool else "false"
 
-
-class SpeedscopeFrame(NamedTuple):
+@dataclass(frozen=True, eq=True)
+class SpeedscopeFrame:
     """
-    Named tuple to store data needed for speedscope's concept of a
+    Data class to store data needed for speedscope's concept of a
     frame, hereafter referred to as a "speedscope frame", as opposed to
     a "pyinstrument frame". This type must be hashable in order to use
     it as a dictionary key; a dictionary will be used to track unique
@@ -40,7 +41,7 @@ class SpeedscopeFrameEncoder(json.JSONEncoder):
     """
     def default(self, o: Any) -> Any:
         if isinstance(o, SpeedscopeFrame):
-            return {"name": o.name, "file": o.file, "line": o.line}
+            return o.__dict__
         return json.JSONEncoder.default(self, o)
 
 
@@ -50,9 +51,10 @@ class SpeedscopeEventType(Enum):
     CLOSE = "C"
 
 
-class SpeedscopeEvent(NamedTuple):
+@dataclass(frozen=True, eq=True)
+class SpeedscopeEvent:
     """
-    Named tuple to store speedscope's concept of an "event", which
+    Data class to store speedscope's concept of an "event", which
     corresponds to opening or closing stack frames as functions or
     methods are entered or exited.
     """
@@ -68,7 +70,7 @@ class SpeedscopeEventEncoder(json.JSONEncoder):
     """
     def default(self, o: Any) -> Any:
         if isinstance(o, SpeedscopeEvent):
-            return {"type": o.type, "at": o.at, "frame": o.frame}
+            return o.__dict__
         if isinstance(o, SpeedscopeEventType):
             return o.value
         return json.JSONEncoder.default(self, o)

--- a/pyinstrument/renderers/speedscope.py
+++ b/pyinstrument/renderers/speedscope.py
@@ -75,16 +75,6 @@ class SpeedscopeEventEncoder(json.JSONEncoder):
         return json.JSONEncoder.default(self, obj)
 
 
-def encode_speedscope_event(event: SpeedscopeEvent) -> str:
-    """Returns a string encoding a SpeedscopeEvent as a JSON object."""
-
-    property_decls: list[str] = []
-    property_decls.append('"type": %s' % encode_str(event.type.value))
-    property_decls.append('"at": %f' % event.at)
-    property_decls.append('"frame": %d' % event.frame)
-
-    return "{%s}" % ",".join(property_decls)
-
 # Dictionaries in Python 3.7+ track insertion order, and
 # dict.popitem() returns (key, value) pair in reverse insertion order
 # (LIFO)

--- a/pyinstrument/renderers/speedscope.py
+++ b/pyinstrument/renderers/speedscope.py
@@ -62,6 +62,19 @@ class SpeedscopeEvent(NamedTuple):
     frame: int
 
 
+class SpeedscopeEventEncoder(json.JSONEncoder):
+    """
+    Encoder used by json.dumps method on SpeedscopeEvent objects to
+    serialize SpeedscopeEvent objects in JSON format.
+    """
+    def default(self, obj):
+        if isinstance(obj, SpeedscopeEvent):
+            return {"type": obj.type, "at": obj.at, "frame": obj.frame}
+        if isinstance(obj, SpeedscopeEventType):
+            return obj.value
+        return json.JSONEncoder.default(self, obj)
+
+
 def encode_speedscope_event(event: SpeedscopeEvent) -> str:
     """Returns a string encoding a SpeedscopeEvent as a JSON object."""
 

--- a/pyinstrument/renderers/speedscope.py
+++ b/pyinstrument/renderers/speedscope.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import json
 import time
 from dataclasses import dataclass
-from typing import Any, Callable
+from typing import Any, Dict, Union
 from enum import Enum
 
 from pyinstrument import processors
@@ -68,9 +68,12 @@ class SpeedscopeFile:
     profiles: list[SpeedscopeProfile]
     shared: dict[str, list[SpeedscopeFrame]]
     schema: str = "https://www.speedscope.app/file-format-schema.json"
-    active_profile_index: NoneType = None
+    active_profile_index: None = None
     exporter: str = "pyinstrument"
 
+
+SpeedscopeFrameDictType = Dict[str, Union[str, int, None]]
+SpeedscopeEventDictType = Dict[str, Union[SpeedscopeEventType, float, int]]
 
 class SpeedscopeEncoder(json.JSONEncoder):
     """
@@ -88,7 +91,8 @@ class SpeedscopeEncoder(json.JSONEncoder):
                     "startValue": o.start_value, "endValue": o.end_value,
                     "events": o.events}
         if isinstance(o, (SpeedscopeFrame, SpeedscopeEvent)):
-            return o.__dict__
+            d: SpeedscopeFrameDictType | SpeedscopeEventDictType = o.__dict__
+            return d
         if isinstance(o, SpeedscopeEventType):
             return o.value
         return json.JSONEncoder.default(self, o)

--- a/pyinstrument/renderers/speedscope.py
+++ b/pyinstrument/renderers/speedscope.py
@@ -34,7 +34,7 @@ class SpeedscopeEventType(Enum):
     CLOSE = "C"
 
 
-@dataclass(frozen=True, eq=True)
+@dataclass
 class SpeedscopeEvent:
     """
     Data class to store speedscope's concept of an "event", which

--- a/pyinstrument/renderers/speedscope.py
+++ b/pyinstrument/renderers/speedscope.py
@@ -28,9 +28,9 @@ class SpeedscopeFrame(NamedTuple):
     it as a dictionary key; a dictionary will be used to track unique
     speedscope frames.
     """
-    name: str
-    file: str
-    line: int
+    name: str | None
+    file: str | None
+    line: int | None
 
 
 class SpeedscopeFrameEncoder(json.JSONEncoder):

--- a/pyinstrument/renderers/speedscope.py
+++ b/pyinstrument/renderers/speedscope.py
@@ -20,15 +20,19 @@ encode_str: Callable[[str], str] = json.encoder.encode_basestring  # type: ignor
 def encode_bool(a_bool: bool):
     return "true" if a_bool else "false"
 
-# Named tuple to store data needed for speedscope's concept of a
-# frame, hereafter referred to as a "speedscope frame", as opposed to
-# a "pyinstrument frame". This type must be hashable in order to use
-# it as a dictionary key; a dictionary will be used to track unique
-# speedscope frames.
-SpeedscopeFrame: NamedTuple = namedtuple(
-    "SpeedscopeFrame",
-    ("name", "file", "line")
-)
+
+class SpeedscopeFrame(NamedTuple):
+    """
+    Named tuple to store data needed for speedscope's concept of a
+    frame, hereafter referred to as a "speedscope frame", as opposed to
+    a "pyinstrument frame". This type must be hashable in order to use
+    it as a dictionary key; a dictionary will be used to track unique
+    speedscope frames.
+    """
+    name: str
+    file: str
+    line: int
+
 
 def encode_speedscope_frame(sframe: SpeedscopeFrame) -> str:
     """Returns a string encoding a SpeedscopeFrame as a JSON object."""

--- a/pyinstrument/renderers/speedscope.py
+++ b/pyinstrument/renderers/speedscope.py
@@ -196,8 +196,9 @@ class SpeedscopeRenderer(Renderer):
                                     self.render_frame(frame),
                                     session.duration)
 
-        # exploits Python 3.7+ dictionary property of iterating over
-        # keys in insertion order
+        # Exploits Python 3.7+ dictionary property of iterating over
+        # keys in insertion order to build the list of speedscope
+        # frames.
         sframe_list: list[SpeedscopeFrame] = []
         for sframe in iter(self._frame_to_index):
             sframe_list.append(sframe)

--- a/pyinstrument/renderers/speedscope.py
+++ b/pyinstrument/renderers/speedscope.py
@@ -206,12 +206,8 @@ class SpeedscopeRenderer(Renderer):
         id_: str = time.strftime("%Y-%m-%dT%H-%M-%S", time.localtime(session.start_time))
         name: str = "CPU profile for {} at {}".format(session.program, id_)
 
-        # Use self._event_time instead of session.duration because there can be
-        # inconsistencies between the two numbers; in the test_speedscope_output
-        # test within test_profiler.py, session.duration is (much) less than
-        # self._event_time (by a factor of at least 150).
         sprofile_list: list[SpeedscopeProfile] = [
-            SpeedscopeProfile(name, self.render_frame(frame), self._event_time)
+            SpeedscopeProfile(name, self.render_frame(frame), session.duration)
         ]
 
         # Exploits Python 3.7+ dictionary property of iterating over

--- a/pyinstrument/renderers/speedscope.py
+++ b/pyinstrument/renderers/speedscope.py
@@ -104,10 +104,6 @@ class SpeedscopeProfileEncoder(json.JSONEncoder):
         return json.JSONEncoder.default(self, o)
 
 
-# Dictionaries in Python 3.7+ track insertion order, and
-# dict.popitem() returns (key, value) pair in reverse insertion order
-# (LIFO)
-
 class SpeedscopeRenderer(Renderer):
     """
     Outputs a tree of JSON conforming to the speedscope schema documented at

--- a/pyinstrument/renderers/speedscope.py
+++ b/pyinstrument/renderers/speedscope.py
@@ -14,8 +14,6 @@ from pyinstrument.session import Session
 # pyright: strict
 
 
-# note: this file is called jsonrenderer to avoid hiding built-in module 'json'.
-
 encode_str: Callable[[str], str] = json.encoder.encode_basestring  # type: ignore
 
 

--- a/pyinstrument/renderers/speedscope.py
+++ b/pyinstrument/renderers/speedscope.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import json
 import time
 from typing import Any, Callable, NamedTuple
-from collections import namedtuple
 from enum import Enum
 
 from pyinstrument import processors

--- a/pyinstrument/renderers/speedscope.py
+++ b/pyinstrument/renderers/speedscope.py
@@ -204,7 +204,7 @@ class SpeedscopeRenderer(Renderer):
         profile_decls.append('"type": %s' % encode_str(profile_type))
 
         profile_name: str = session.program
-        profile_decls.append('"name": %s' % encode_str(session.program))
+        profile_decls.append('"name": %s' % encode_str(profile_name))
 
         unit: str = "seconds"
         profile_decls.append('"unit": %s' % encode_str(unit))

--- a/pyinstrument/renderers/speedscope.py
+++ b/pyinstrument/renderers/speedscope.py
@@ -39,10 +39,10 @@ class SpeedscopeFrameEncoder(json.JSONEncoder):
     Encoder used by json.dumps method on SpeedscopeFrame objects to serialize
     SpeedscopeEvent objects in JSON format.
     """
-    def default(self, obj):
-        if isinstance(obj, SpeedscopeFrame):
-            return {"name": obj.name, "file": obj.file, "line": obj.line}
-        return json.JSONEncoder.default(self, obj)
+    def default(self, o: Any) -> Any:
+        if isinstance(o, SpeedscopeFrame):
+            return {"name": o.name, "file": o.file, "line": o.line}
+        return json.JSONEncoder.default(self, o)
 
 
 class SpeedscopeEventType(Enum):
@@ -67,12 +67,12 @@ class SpeedscopeEventEncoder(json.JSONEncoder):
     Encoder used by json.dumps method on SpeedscopeEvent objects to
     serialize SpeedscopeEvent objects in JSON format.
     """
-    def default(self, obj):
-        if isinstance(obj, SpeedscopeEvent):
-            return {"type": obj.type, "at": obj.at, "frame": obj.frame}
-        if isinstance(obj, SpeedscopeEventType):
-            return obj.value
-        return json.JSONEncoder.default(self, obj)
+    def default(self, o: Any) -> Any:
+        if isinstance(o, SpeedscopeEvent):
+            return {"type": o.type, "at": o.at, "frame": o.frame}
+        if isinstance(o, SpeedscopeEventType):
+            return o.value
+        return json.JSONEncoder.default(self, o)
 
 
 # Dictionaries in Python 3.7+ track insertion order, and

--- a/pyinstrument/renderers/speedscope.py
+++ b/pyinstrument/renderers/speedscope.py
@@ -34,6 +34,17 @@ class SpeedscopeFrame(NamedTuple):
     line: int
 
 
+class SpeedscopeFrameEncoder(json.JSONEncoder):
+    """
+    Encoder used by json.dumps method on SpeedscopeFrame objects to serialize
+    SpeedscopeEvent objects in JSON format.
+    """
+    def default(self, obj):
+        if isinstance(obj, SpeedscopeFrame):
+            return {"name": obj.name, "file": obj.file, "line": obj.line}
+        return json.JSONEncoder.default(self, obj)
+
+
 def encode_speedscope_frame(sframe: SpeedscopeFrame) -> str:
     """Returns a string encoding a SpeedscopeFrame as a JSON object."""
 

--- a/pyinstrument/renderers/speedscope.py
+++ b/pyinstrument/renderers/speedscope.py
@@ -210,10 +210,14 @@ class SpeedscopeRenderer(Renderer):
         return "%s\n" % json.dumps(speedscope_file, cls=SpeedscopeEncoder)
 
     def default_processors(self) -> ProcessorList:
+        """
+        Default Processors for speedscope renderer; note that
+        processors.aggregate_repeated_calls is removed because
+        speedscope is a timeline-based format.
+        """
         return [
             processors.remove_importlib,
             processors.merge_consecutive_self_time,
-            processors.aggregate_repeated_calls,
             processors.group_library_frames_processor,
             processors.remove_unnecessary_self_time_nodes,
             processors.remove_irrelevant_nodes,

--- a/pyinstrument/renderers/speedscope.py
+++ b/pyinstrument/renderers/speedscope.py
@@ -157,7 +157,7 @@ class SpeedscopeRenderer(Renderer):
             sframe_index
         )
 
-        event_array: list[str] = [encode_speedscope_event(open_event)]
+        event_array: list[str] = [json.dumps(open_event, cls=SpeedscopeEventEncoder)]
 
         for child in frame.children:
             child_events = self.render_frame(child)
@@ -183,7 +183,7 @@ class SpeedscopeRenderer(Renderer):
             self._event_time,
             sframe_index
         )
-        event_array.append(encode_speedscope_event(close_event))
+        event_array.append(json.dumps(close_event, cls=SpeedscopeEventEncoder))
 
         # Omit enclosing square brackets here; these brackets are applied in
         # the render method

--- a/pyinstrument/renderers/speedscope.py
+++ b/pyinstrument/renderers/speedscope.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+import json
+from typing import Any, Callable
+
+from pyinstrument import processors
+from pyinstrument.frame import BaseFrame
+from pyinstrument.renderers.base import ProcessorList, Renderer
+from pyinstrument.session import Session
+
+# pyright: strict
+
+
+# note: this file is called jsonrenderer to avoid hiding built-in module 'json'.
+
+encode_str: Callable[[str], str] = json.encoder.encode_basestring  # type: ignore
+
+
+def encode_bool(a_bool: bool):
+    return "true" if a_bool else "false"
+
+
+class SpeedscopeRenderer(Renderer):
+    """
+    Outputs a tree of JSON, containing processed frames.
+    """
+
+    def __init__(self, **kwargs: Any):
+        super().__init__(**kwargs)
+
+    def render_frame(self, frame: BaseFrame | None):
+        if frame is None:
+            return "null"
+        # we don't use the json module because it uses 2x stack frames, so
+        # crashes on deep but valid call stacks
+
+        property_decls: list[str] = []
+        property_decls.append('"function": %s' % encode_str(frame.function or ""))
+        property_decls.append('"file_path_short": %s' % encode_str(frame.file_path_short or ""))
+        property_decls.append('"file_path": %s' % encode_str(frame.file_path or ""))
+        property_decls.append('"line_no": %d' % frame.line_no)
+        property_decls.append('"time": %f' % frame.time())
+        property_decls.append('"await_time": %f' % frame.await_time())
+        property_decls.append(
+            '"is_application_code": %s' % encode_bool(frame.is_application_code or False)
+        )
+
+        # can't use list comprehension here because it uses two stack frames each time.
+        children_jsons: list[str] = []
+        for child in frame.children:
+            children_jsons.append(self.render_frame(child))
+        property_decls.append('"children": [%s]' % ",".join(children_jsons))
+
+        if frame.group:
+            property_decls.append('"group_id": %s' % encode_str(frame.group.id))
+
+        return "{%s}" % ",".join(property_decls)
+
+    def render(self, session: Session):
+        frame = self.preprocess(session.root_frame())
+
+        property_decls: list[str] = []
+        property_decls.append('"start_time": %f' % session.start_time)
+        property_decls.append('"duration": %f' % session.duration)
+        property_decls.append('"sample_count": %d' % session.sample_count)
+        property_decls.append('"program": %s' % encode_str(session.program))
+        if session.cpu_time is None:
+            property_decls.append('"cpu_time": null')
+        else:
+            property_decls.append('"cpu_time": %f' % session.cpu_time)
+        property_decls.append('"root_frame": %s' % self.render_frame(frame))
+
+        return "{%s}\n" % ",".join(property_decls)
+
+    def default_processors(self) -> ProcessorList:
+        return [
+            processors.remove_importlib,
+            processors.merge_consecutive_self_time,
+            processors.aggregate_repeated_calls,
+            processors.group_library_frames_processor,
+            processors.remove_unnecessary_self_time_nodes,
+            processors.remove_irrelevant_nodes,
+        ]

--- a/pyinstrument/renderers/speedscope.py
+++ b/pyinstrument/renderers/speedscope.py
@@ -46,8 +46,8 @@ class SpeedscopeFrameEncoder(json.JSONEncoder):
 
 class SpeedscopeEventType(Enum):
     """Enum representing the only two types of speedscope frame events"""
-    OPEN: str = "O"
-    CLOSE: str = "C"
+    OPEN = "O"
+    CLOSE = "C"
 
 
 class SpeedscopeEvent(NamedTuple):

--- a/pyinstrument/renderers/speedscope.py
+++ b/pyinstrument/renderers/speedscope.py
@@ -196,7 +196,9 @@ class SpeedscopeRenderer(Renderer):
     def render(self, session: Session):
         frame = self.preprocess(session.root_frame())
 
-        sprofile = SpeedscopeProfile(session.program,
+        id_: str = time.strftime("%Y-%m-%dT%H-%M-%S", time.localtime(session.start_time))
+        name: str = "CPU profile for {} at {}".format(session.program, id_)
+        sprofile = SpeedscopeProfile(name,
                                     self.render_frame(frame),
                                     session.duration)
 
@@ -206,8 +208,6 @@ class SpeedscopeRenderer(Renderer):
         sframe_list: list[SpeedscopeFrame] = [
             sframe for sframe in iter(self._frame_to_index)]
 
-        id_: str = time.strftime("%Y-%m-%dT%H-%M-%S", time.localtime(session.start_time))
-        name: str = "CPU profile for {} at {}".format(session.program, id_)
         shared_dict = {"frames": sframe_list}
         speedscope_file = SpeedscopeFile(name, [sprofile], shared_dict)
 

--- a/test/test_overflow.py
+++ b/test/test_overflow.py
@@ -5,7 +5,7 @@ import time
 import pytest
 
 from pyinstrument import Profiler
-from pyinstrument.renderers import ConsoleRenderer, HTMLRenderer, JSONRenderer
+from pyinstrument.renderers import ConsoleRenderer, HTMLRenderer, JSONRenderer, SpeedscopeRenderer
 
 # Utilities
 
@@ -56,3 +56,7 @@ def test_html(deep_profiler_session):
 
 def test_json(deep_profiler_session):
     JSONRenderer().render(deep_profiler_session)
+
+
+def test_speedscope(deep_profiler_session):
+    SpeedscopeRenderer().render(deep_profiler_session)

--- a/test/test_profiler.py
+++ b/test/test_profiler.py
@@ -201,6 +201,9 @@ def test_speedscope_output():
             profile_field in speedscope_profile
         ), f"Field named '{profile_field}' not in Speedscope output at 'profiles[0]'"
 
+    # speedscope_profile["endValue"] is not tested because a fake_time mock
+    # timer is used to replace time.time, and this mock causes session.duration
+    # to differ from self._event_time just before exiting SpeedscopeRenderer.render
     start_time_in_seconds = 0.0
     event_time_in_seconds = start_time_in_seconds
     assert speedscope_profile["type"] == "evented"
@@ -311,10 +314,6 @@ def test_speedscope_output():
             f"{speedscope_event_time_in_seconds} != {output_event_time_in_seconds} "
             f"+/- {output_event_time_abs_tol}"
         )
-
-    assert speedscope_profile["endValue"] == pytest.approx(
-        event_time_in_seconds, abs=get_approx_abs_tol(event_time_in_seconds)
-    )
 
 
 def test_empty_profile():

--- a/test/test_profiler.py
+++ b/test/test_profiler.py
@@ -1,4 +1,5 @@
 import asyncio
+import dataclasses
 import json
 import time
 from functools import partial
@@ -10,6 +11,7 @@ import trio
 
 from pyinstrument import Profiler, renderers
 from pyinstrument.frame import BaseFrame, Frame
+from pyinstrument.renderers.speedscope import SpeedscopeEvent, SpeedscopeEventType, SpeedscopeFrame
 from pyinstrument.session import Session
 
 from .util import assert_never, busy_wait, flaky_in_ci
@@ -136,6 +138,183 @@ def test_json_output():
 
     assert root_frame["function"] == "test_json_output"
     assert len(root_frame["children"]) == 2
+
+
+def test_speedscope_output():
+    with fake_time():
+        with Profiler() as profiler:
+            long_function_a()
+            long_function_b()
+
+    output_data = profiler.output(renderers.SpeedscopeRenderer())
+
+    output = json.loads(output_data)
+
+    file_level_schema_fields = {
+        "$schema",
+        "name",
+        "exporter",
+        "activeProfileIndex",
+        "profiles",
+        "shared",
+    }
+    for file_field in file_level_schema_fields:
+        assert file_field in output
+
+    assert output["$schema"] == "https://www.speedscope.app/file-format-schema.json"
+    assert "pyinstrument" in output["exporter"]
+    assert output["activeProfileIndex"] is None
+    assert "CPU profile" in output["name"]
+
+    assert "frames" in output["shared"]
+    speedscope_frame_list = output["shared"]["frames"]
+
+    # Distinct functions called stores indices in key-value pairs because function
+    # index lookup needed for Speedscope event list tests. Were we not testing
+    # the event list, the distinct functions called could be stored as a tuple.
+    distinct_functions_called = {
+        "test_speedscope_output": 0,
+        "long_function_a": 1,
+        "sleep": 2,
+        "long_function_b": 3,
+    }
+    assert len(speedscope_frame_list) == len(distinct_functions_called)
+    speedscope_frame_fields = tuple([field.name for field in dataclasses.fields(SpeedscopeFrame)])
+    for (function_name, frame_index) in distinct_functions_called.items():
+        for frame_field in speedscope_frame_fields:
+            assert frame_field in speedscope_frame_list[frame_index], (
+                f"Field named '{frame_field}' not in Speedscope output"
+                f"at 'shared.frames[{frame_index}]'"
+            )
+        frame_index_name = speedscope_frame_list[frame_index]["name"]
+        assert frame_index_name == function_name, (
+            f"Speedscope output 'shared.frames[{frame_index}].name' has value "
+            f"{frame_index_name} != {function_name}"
+        )
+
+    speedscope_profile_list = output["profiles"]
+    assert len(speedscope_profile_list) == 1
+    speedscope_profile = speedscope_profile_list[0]
+    speedscope_profile_fields = ("type", "name", "unit", "startValue", "endValue", "events")
+    for profile_field in speedscope_profile_fields:
+        assert (
+            profile_field in speedscope_profile
+        ), f"Field named '{profile_field}' not in Speedscope output at 'profiles[0]'"
+
+    start_time_in_seconds = 0.0
+    event_time_in_seconds = start_time_in_seconds
+    assert speedscope_profile["type"] == "evented"
+    assert speedscope_profile["unit"] == "seconds"
+    assert speedscope_profile["startValue"] == start_time_in_seconds
+
+    """Two helper functions for constructing a timeline and testing it"""
+
+    def update_event_time_on_sleep_close(time_increment_in_seconds: float):
+        """Updates running total of event time in seconds and returns updated value"""
+        nonlocal event_time_in_seconds
+        event_time_in_seconds += time_increment_in_seconds
+        return event_time_in_seconds
+
+    def get_approx_abs_tol(time_in_seconds: float):
+        """Computes absolute tolerance for given time value to account for CI time jitter"""
+        uncertainty_per_quarter_second = 0.1
+        absolute_tolerance = (time_in_seconds / 0.25) * uncertainty_per_quarter_second
+        return absolute_tolerance
+
+    speedscope_event_list = speedscope_profile["events"]
+    sleep_a_time_in_seconds = 0.25
+    sleep_b_time_in_seconds = 0.5
+
+    output_event_tuple = (
+        SpeedscopeEvent(
+            SpeedscopeEventType.OPEN,
+            event_time_in_seconds,
+            distinct_functions_called["test_speedscope_output"],
+        ),
+        SpeedscopeEvent(
+            SpeedscopeEventType.OPEN,
+            event_time_in_seconds,
+            distinct_functions_called["long_function_a"],
+        ),
+        SpeedscopeEvent(
+            SpeedscopeEventType.OPEN,
+            event_time_in_seconds,
+            distinct_functions_called["sleep"],
+        ),
+        SpeedscopeEvent(
+            SpeedscopeEventType.CLOSE,
+            update_event_time_on_sleep_close(sleep_a_time_in_seconds),
+            distinct_functions_called["sleep"],
+        ),
+        SpeedscopeEvent(
+            SpeedscopeEventType.CLOSE,
+            event_time_in_seconds,
+            distinct_functions_called["long_function_a"],
+        ),
+        SpeedscopeEvent(
+            SpeedscopeEventType.OPEN,
+            event_time_in_seconds,
+            distinct_functions_called["long_function_b"],
+        ),
+        SpeedscopeEvent(
+            SpeedscopeEventType.OPEN,
+            event_time_in_seconds,
+            distinct_functions_called["sleep"],
+        ),
+        SpeedscopeEvent(
+            SpeedscopeEventType.CLOSE,
+            update_event_time_on_sleep_close(sleep_b_time_in_seconds),
+            distinct_functions_called["sleep"],
+        ),
+        SpeedscopeEvent(
+            SpeedscopeEventType.CLOSE,
+            event_time_in_seconds,
+            distinct_functions_called["long_function_b"],
+        ),
+        SpeedscopeEvent(
+            SpeedscopeEventType.CLOSE,
+            event_time_in_seconds,
+            distinct_functions_called["test_speedscope_output"],
+        ),
+    )
+
+    assert len(speedscope_event_list) == len(output_event_tuple)
+    speedscope_event_fields = tuple([field.name for field in dataclasses.fields(SpeedscopeEvent)])
+    for (event_index, speedscope_event) in enumerate(speedscope_event_list):
+        for event_field in speedscope_event_fields:
+            assert event_field in speedscope_event, (
+                f"Speedscope output 'profiles[0].events[{event_index}]' lacks "
+                f"a field named '{event_field}'"
+            )
+
+        output_event_type = output_event_tuple[event_index].type.value
+        speedscope_event_type = speedscope_event["type"]
+        assert speedscope_event["type"] == output_event_tuple[event_index].type.value, (
+            f"Speedscope output 'profiles[0].events[{event_index}].type has "
+            f"value {speedscope_event_type} != {output_event_type}"
+        )
+
+        output_event_frame_index = output_event_tuple[event_index].frame
+        speedscope_event_frame_index = speedscope_event["frame"]
+        assert speedscope_event_frame_index == output_event_frame_index, (
+            f"Speedscope output 'profiles[0].events[{event_index}].frame has "
+            f"value {speedscope_event_frame_index} != {output_event_frame_index}"
+        )
+
+        output_event_time_in_seconds = output_event_tuple[event_index].at
+        output_event_time_abs_tol = get_approx_abs_tol(output_event_time_in_seconds)
+        speedscope_event_time_in_seconds = speedscope_event["at"]
+        assert speedscope_event_time_in_seconds == pytest.approx(
+            output_event_time_in_seconds, abs=output_event_time_abs_tol
+        ), (
+            f"Speedscope output 'profiles[0].events[{event_index}].at has value "
+            f"{speedscope_event_time_in_seconds} != {output_event_time_in_seconds} "
+            f"+/- {output_event_time_abs_tol}"
+        )
+
+    assert speedscope_profile["endValue"] == pytest.approx(
+        event_time_in_seconds, abs=get_approx_abs_tol(event_time_in_seconds)
+    )
 
 
 def test_empty_profile():


### PR DESCRIPTION
This pull request adds a renderer that outputs JSON conforming to  [speedscope](https://github.com/jlfwong/speedscope)'s JSON schema; in particular, speedscope's "evented" format is used.

This implementation is very rough, and intended as a request for comment. I expect to revise this pull request based on feedback from the project maintainer(s) to better conform with project style.

Closes #89.