### PR TITLE
chore: add py.typed file to source

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,3 +4,4 @@ recursive-include pyinstrument *.js
 recursive-include html_renderer *.html *.json *.js *.ts *.vue *.css *.png
 prune html_renderer/node_modules
 prune html_renderer/dist
+include pyinstrument/py.typed


### PR DESCRIPTION
The package seems to be very nicely typed, so is there any reason to not add this?