### PR TITLE
Relative percentage display for Console output

### DIFF
--- a/pyinstrument/__main__.py
+++ b/pyinstrument/__main__.py
@@ -162,6 +162,14 @@ def main():
         help="show everything",
         default=False,
     )
+    parser.add_option(
+        "",
+        "--show-percentage",
+        dest="show_percentage",
+        action="store_true",
+        help="(text renderer only) show relative percentages alongside timings",
+        default=False,
+    )
 
     parser.add_option(
         "",
@@ -299,7 +307,9 @@ def main():
         unicode: Any = options.unicode if unicode_override else file_supports_unicode(f)
         color: Any = options.color if color_override else file_supports_color(f)
 
-        renderer_kwargs.update({"unicode": unicode, "color": color})
+        renderer_kwargs.update(
+            {"unicode": unicode, "color": color, "show_percentage": options.show_percentage}
+        )
 
     renderer_class = get_renderer_class(options.renderer)
     renderer = renderer_class(**renderer_kwargs)

--- a/pyinstrument/frame.py
+++ b/pyinstrument/frame.py
@@ -65,6 +65,14 @@ class BaseFrame:
         self._self_time = self_time
         self._invalidate_time_caches()
 
+    @property
+    def perc(self) -> float | None:
+        return self._perc
+
+    @perc.setter
+    def perc(self, val: float):
+        self._perc = val
+
     # invalidates the cache for the time() function.
     # called whenever self_time or _children is modified.
     def _invalidate_time_caches(self):
@@ -139,6 +147,7 @@ class Frame(BaseFrame):
         self._children = []
 
         self._time = None
+        self._perc = None
         self._await_time = None
 
         if children:
@@ -291,11 +300,12 @@ class Frame(BaseFrame):
             frame._await_time = None
 
     def __repr__(self):
-        return "Frame(identifier=%s, time=%f, len(children)=%d), group=%r" % (
+        return "Frame(identifier=%s, time=%f, len(children)=%d), group=%r, perc=%r" % (
             self.identifier,
             self.time(),
             len(self.children),
             self.group,
+            self.perc,
         )
 
 

--- a/pyinstrument/processors.py
+++ b/pyinstrument/processors.py
@@ -215,3 +215,32 @@ def remove_irrelevant_nodes(
         remove_irrelevant_nodes(child, options=options, total_time=total_time)
 
     return frame
+
+
+def compute_relative_percentage(
+    frame: BaseFrame | None, options: ProcessorOptions
+) -> BaseFrame | None:
+    """
+    Compute the relative percentage amongst siblings
+    """
+
+    def _compute_layer_percentage(frame: BaseFrame):
+        total_time = frame.time()
+
+        for child in frame.children:
+            child.perc = child.time() / total_time
+            child = _compute_layer_percentage(child)
+
+        if len(frame.children) == 0:
+            frame.perc = 1.0
+
+        return frame
+
+    if frame is None:
+        return None
+
+    frame = _compute_layer_percentage(frame)
+
+    frame.perc = 1.0
+
+    return frame

--- a/pyinstrument/profiler.py
+++ b/pyinstrument/profiler.py
@@ -256,8 +256,9 @@ class Profiler:
         color: bool | None = None,
         show_all: bool = False,
         timeline: bool = False,
+        show_percentage: bool = False,
     ):
-        """print(file=sys.stdout, *, unicode=None, color=None, show_all=False, timeline=False)
+        """print(file=sys.stdout, *, unicode=None, color=None, show_all=False, timeline=False, show_percentage=False)
 
         Print the captured profile to the console.
 
@@ -266,6 +267,7 @@ class Profiler:
         :param color: Override ANSI color support detection.
         :param show_all: Sets the ``show_all`` parameter on the renderer.
         :param timeline: Sets the ``timeline`` parameter on the renderer.
+        :param show_percentage: Sets the ``show_percentage`` parameter on the renderer.
         """
         if unicode is None:
             unicode = file_supports_unicode(file)
@@ -278,6 +280,7 @@ class Profiler:
                 color=color,
                 show_all=show_all,
                 timeline=timeline,
+                show_percentage=show_percentage,
             ),
             file=file,
         )
@@ -288,13 +291,18 @@ class Profiler:
         color: bool = False,
         show_all: bool = False,
         timeline: bool = False,
+        show_percentage: bool = False,
     ) -> str:
         """
         Return the profile output as text, as rendered by :class:`ConsoleRenderer`
         """
         return self.output(
             renderer=renderers.ConsoleRenderer(
-                unicode=unicode, color=color, show_all=show_all, timeline=timeline
+                unicode=unicode,
+                color=color,
+                show_all=show_all,
+                timeline=timeline,
+                show_percentage=show_percentage,
             )
         )
 


### PR DESCRIPTION
Hello!

First of all, thanks for the great package. I discovered it recently but am already a big fan of it! 🎇

Issue #132 and issue #171 mentioned the fact that displaying percentages alongside actual timings could be interesting. The kind of percentages discussed in the two issues are not exactly the same. #171 mentioned the percentage of time a frame took to execute compared to **the whole execution time** while #132 mentioned the percentages of time a frame took **relatively to its direct siblings**.

Since I am also interested in this kind feature, I have implemented a specific processor that computes the percentage of time for a specific frame given its direct siblings. Switching to the overall execution percentage should be easy by modifying the said processor.

Plus, I modified the ConsoleRenderer and the Profiler classes by adding a parameter that controls whether those percentages should be displayed or not. Finally, I added a command line switch that would trigger the

Here's what it looks like:

![image](https://user-images.githubusercontent.com/10131735/148259599-1fa20461-85b6-4cdf-8ff1-1be41adc285b.png)

I did not push the development too far (like adding that to the HTML output) for the moment to leave room for discussion, but if you think that such changes could be of any interest, I'll gladly add support to HTML / JSONRenderers!

Have a nice day 🚀