### PR TITLE
Allow --load-prev from file if it exists

### DIFF
--- a/pyinstrument/__main__.py
+++ b/pyinstrument/__main__.py
@@ -52,7 +52,7 @@ def main():
         "--load-prev",
         dest="load_prev",
         action="store",
-        metavar="ID",
+        metavar="ID-OR-FILENAME",
         help="instead of running a script, load a previous report",
     )
 
@@ -344,11 +344,15 @@ def report_dir() -> str:
     return report_dir
 
 
-def load_report(identifier: str) -> Session:
+def load_report(identifier_or_path: str) -> Session:
     """
     Returns the session referred to by identifier
     """
-    path = os.path.join(report_dir(), identifier + ".pyisession")
+    path = os.path.join(report_dir(), identifier_or_path + ".pyisession")
+
+    if os.path.exists(identifier_or_path) and not os.path.exists(path):
+        path = identifier_or_path
+
     return Session.load(path)
 
 


### PR DESCRIPTION
The previous behaviour of loading from the report
directory is still kept as the default.

However, if the argument is a valid path for an
existing file and NOT a valid identifier, load
from the file instead.

This is handy when reports get copied around
and shared between different people and systems.