### PR TITLE
Add cmdline interface for renderer options and add percent_of_total option

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,7 @@ repos:
         name: isort (python)
 
 -   repo: https://github.com/psf/black
-    rev: 20.8b1
+    rev: 22.3.0
     hooks:
       - id: black
         language_version: python3

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,7 +34,7 @@ repos:
         language: node
         pass_filenames: false
         types: [python]
-        additional_dependencies: ['pyright@1.1.134']
+        additional_dependencies: ['pyright@1.1.245']
     -   id: build
         name: build js bundle
         entry: bin/build_js_bundle.py --force

--- a/pyinstrument/__main__.py
+++ b/pyinstrument/__main__.py
@@ -93,14 +93,14 @@ def main():
 
     parser.add_option(
         "-p",
-        "--renderer-option",
+        "--render-option",
         dest="renderer_options",
         action="append",
         metavar="RENDERER_OPTION",
         type="string",
         help=(
             "options to pass to the renderer, in the format 'flag_name' or 'option_name=option_value'. "
-            "For example, to set the flag show_percentages, pass '-p show_percentages'. To pass multiple "
+            "For example, to set the option 'time', pass '-p time=percent_of_total'. To pass multiple "
             "options, use the -p flag multiple times."
         ),
     )

--- a/pyinstrument/__main__.py
+++ b/pyinstrument/__main__.py
@@ -101,7 +101,8 @@ def main():
         help=(
             "options to pass to the renderer, in the format 'flag_name' or 'option_name=option_value'. "
             "For example, to set the option 'time', pass '-p time=percent_of_total'. To pass multiple "
-            "options, use the -p flag multiple times."
+            "options, use the -p option multiple times. You can pass a string or a JSON value as "
+            "option_value, e.g. `-p 'processor_options={\"filter_threshold\": 0}'`"
         ),
     )
 

--- a/pyinstrument/__main__.py
+++ b/pyinstrument/__main__.py
@@ -109,8 +109,9 @@ def main():
         help=(
             "options to pass to the renderer, in the format 'flag_name' or 'option_name=option_value'. "
             "For example, to set the option 'time', pass '-p time=percent_of_total'. To pass multiple "
-            "options, use the -p option multiple times. You can pass a string or a JSON value as "
-            "option_value, e.g. `-p 'processor_options={\"filter_threshold\": 0}'`"
+            "options, use the -p option multiple times. You can set processor options using dot-syntax, "
+            "like '-p processor_options.filter_threshold=0'. option_value is parsed as a JSON value or "
+            "a string."
         ),
     )
 

--- a/pyinstrument/__main__.py
+++ b/pyinstrument/__main__.py
@@ -96,11 +96,12 @@ def main():
         "--renderer-option",
         dest="renderer_options",
         action="append",
+        metavar="RENDERER_OPTION",
         type="string",
         help=(
             "options to pass to the renderer, in the format 'flag_name' or 'option_name=option_value'. "
-            "For example, to set the flag show_percentages, pass '-o show_percentages'. To pass multiple "
-            "options, use the -o flag multiple times."
+            "For example, to set the flag show_percentages, pass '-p show_percentages'. To pass multiple "
+            "options, use the -p flag multiple times."
         ),
     )
 

--- a/pyinstrument/__main__.py
+++ b/pyinstrument/__main__.py
@@ -94,9 +94,9 @@ def main():
     parser.add_option(
         "-p",
         "--render-option",
-        dest="renderer_options",
+        dest="render_options",
         action="append",
-        metavar="RENDERER_OPTION",
+        metavar="RENDER_OPTION",
         type="string",
         help=(
             "options to pass to the renderer, in the format 'flag_name' or 'option_name=option_value'. "
@@ -315,7 +315,7 @@ def main():
         print("")
 
 
-def compute_renderer_options(options: CommandLineOptions, output_file: TextIO) -> dict[str, Any]:
+def compute_render_options(options: CommandLineOptions, output_file: TextIO) -> dict[str, Any]:
     # parse show/hide options
     if options.hide_fnmatch is not None and options.hide_regex is not None:
         raise OptionsParseError("You can‘t specify both --hide and --hide-regex")
@@ -342,7 +342,7 @@ def compute_renderer_options(options: CommandLineOptions, output_file: TextIO) -
     else:
         show_regex = options.show_regex
 
-    renderer_options: dict[str, Any] = {
+    render_options: dict[str, Any] = {
         "processor_options": {
             "hide_regex": hide_regex,
             "show_regex": show_regex,
@@ -350,7 +350,7 @@ def compute_renderer_options(options: CommandLineOptions, output_file: TextIO) -
     }
 
     if options.timeline is not None:
-        renderer_options["timeline"] = options.timeline
+        render_options["timeline"] = options.timeline
 
     if options.renderer == "text":
         unicode_override = options.unicode is not None
@@ -358,16 +358,16 @@ def compute_renderer_options(options: CommandLineOptions, output_file: TextIO) -
         unicode: Any = options.unicode if unicode_override else file_supports_unicode(output_file)
         color: Any = options.color if color_override else file_supports_color(output_file)
 
-        renderer_options.update({"unicode": unicode, "color": color})
+        render_options.update({"unicode": unicode, "color": color})
 
     # apply user options
-    if options.renderer_options is not None:
-        for renderer_option in options.renderer_options:
+    if options.render_options is not None:
+        for renderer_option in options.render_options:
             key, sep, value = renderer_option.partition("=")
 
             if sep == "":
                 # we're setting a flag, like `-p unicode`
-                keypath.set_value_at_keypath(renderer_options, key, True)
+                keypath.set_value_at_keypath(render_options, key, True)
             else:
                 # it's a key=value structure
                 try:
@@ -377,9 +377,9 @@ def compute_renderer_options(options: CommandLineOptions, output_file: TextIO) -
                     # otherwise treat it as a string
                     parsed_value = value
 
-                keypath.set_value_at_keypath(renderer_options, key, parsed_value)
+                keypath.set_value_at_keypath(render_options, key, parsed_value)
 
-    return renderer_options
+    return render_options
 
 
 class OptionsParseError(Exception):
@@ -390,11 +390,11 @@ def create_renderer(options: CommandLineOptions, output_file: TextIO) -> rendere
     if options.output_html:
         options.renderer = "html"
 
-    renderer_options = compute_renderer_options(options, output_file=output_file)
+    render_options = compute_render_options(options, output_file=output_file)
     renderer_class = get_renderer_class(options.renderer)
 
     try:
-        return renderer_class(**renderer_options)
+        return renderer_class(**render_options)
     except TypeError as err:
         # TypeError is probably a bad renderer option, so we produce a nicer error message
         raise OptionsParseError(
@@ -498,7 +498,7 @@ class CommandLineOptions:
     show_all: bool
     output_html: bool
     outfile: str | None
-    renderer_options: list[str] | None
+    render_options: list[str] | None
 
     unicode: bool | None
     color: bool | None

--- a/pyinstrument/__main__.py
+++ b/pyinstrument/__main__.py
@@ -374,7 +374,7 @@ def compute_render_options(options: CommandLineOptions, output_file: TextIO) -> 
                 try:
                     # try parsing as a JSON value
                     parsed_value = json.loads(value)
-                except:
+                except json.JSONDecodeError:
                     # otherwise treat it as a string
                     parsed_value = value
 

--- a/pyinstrument/processors.py
+++ b/pyinstrument/processors.py
@@ -95,8 +95,18 @@ def group_library_frames_processor(
 ) -> BaseFrame | None:
     """
     Groups frames that should be hidden into :class:`FrameGroup` objects,
-    according to ``hide_regex`` and ``show_regex`` in the options dict. If
-    both match, 'show' has precedence.
+    according to ``hide_regex`` and ``show_regex`` in the options dict, as
+    applied to the file path of the source code of the frame. If both match,
+    'show' has precedence.
+    Options:
+
+    ``hide_regex``
+      regular expression, which if matches the file path, hides the frame in a
+      frame group.
+
+    ``show_regex``
+      regular expression, which if matches the file path, ensures the frame is
+      not hidden
 
     Single frames are not grouped, there must be at least two frames in a
     group.
@@ -194,7 +204,11 @@ def remove_irrelevant_nodes(
     frame: BaseFrame | None, options: ProcessorOptions, total_time: float | None = None
 ) -> BaseFrame | None:
     """
-    Remove nodes that represent less than e.g. 1% of the output.
+    Remove nodes that represent less than e.g. 1% of the output. Options:
+
+    ``filter_threshold``
+      sets the minimum duration of a frame to be included in the output.
+      Default: 0.01.
     """
     if frame is None:
         return None

--- a/pyinstrument/renderers/console.py
+++ b/pyinstrument/renderers/console.py
@@ -28,6 +28,7 @@ class ConsoleRenderer(Renderer):
         """
         :param unicode: Use unicode, like box-drawing characters in the output.
         :param color: Enable color support, using ANSI color sequences.
+        :param time: How to display the duration of each frame - ``'seconds'`` or ``'percent_of_total'``
         """
         super().__init__(**kwargs)
 

--- a/pyinstrument/stack_sampler.py
+++ b/pyinstrument/stack_sampler.py
@@ -6,7 +6,7 @@ import types
 from contextvars import ContextVar
 from typing import Any, Callable, List, NamedTuple, Optional
 
-from pyinstrument.low_level.stat_profile import setstatprofile
+from pyinstrument.low_level.stat_profile import setstatprofile  # type: ignore
 from pyinstrument.typing import LiteralStr
 
 # pyright: strict

--- a/pyinstrument/util.py
+++ b/pyinstrument/util.py
@@ -3,12 +3,12 @@ import importlib
 import os
 import sys
 import warnings
-from typing import IO
+from typing import IO, Any, AnyStr
 
 from pyinstrument.vendor.decorator import decorator
 
 
-def object_with_import_path(import_path):
+def object_with_import_path(import_path: str) -> Any:
     if "." not in import_path:
         raise ValueError("Can't import '%s', it is not a valid import path" % import_path)
     module_path, object_name = import_path.rsplit(".", 1)
@@ -25,7 +25,7 @@ def truncate(string: str, max_length: int):
 
 @decorator
 def deprecated(func, *args, **kwargs):
-    """ Marks a function as deprecated. """
+    """Marks a function as deprecated."""
     warnings.warn(
         f"{func} is deprecated and should no longer be used.",
         DeprecationWarning,
@@ -35,7 +35,7 @@ def deprecated(func, *args, **kwargs):
 
 
 def deprecated_option(option_name, message=""):
-    """ Marks an option as deprecated. """
+    """Marks an option as deprecated."""
 
     def caller(func, *args, **kwargs):
         if option_name in kwargs:
@@ -50,7 +50,7 @@ def deprecated_option(option_name, message=""):
     return decorator(caller)
 
 
-def file_supports_color(file_obj: IO) -> bool:
+def file_supports_color(file_obj: IO[AnyStr]) -> bool:
     """
     Returns True if the running system's terminal supports color.
 
@@ -65,7 +65,7 @@ def file_supports_color(file_obj: IO) -> bool:
     return supported_platform and is_a_tty
 
 
-def file_supports_unicode(file_obj: IO) -> bool:
+def file_supports_unicode(file_obj: IO[AnyStr]) -> bool:
     encoding = getattr(file_obj, "encoding", None)
     if not encoding:
         return False
@@ -75,5 +75,5 @@ def file_supports_unicode(file_obj: IO) -> bool:
     return "utf" in codec_info.name
 
 
-def file_is_a_tty(file_obj: IO) -> bool:
+def file_is_a_tty(file_obj: IO[AnyStr]) -> bool:
     return hasattr(file_obj, "isatty") and file_obj.isatty()

--- a/pyinstrument/vendor/keypath.py
+++ b/pyinstrument/vendor/keypath.py
@@ -1,0 +1,90 @@
+# keypath vendored from https://github.com/fictorial/keypath
+
+# keypath is released under the BSD license:
+
+# Copyright 2016, Fictorial LLC
+
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+
+#     * Redistributions of source code must retain the above
+#       copyright notice, this list of conditions and the following
+#       disclaimer.
+
+#     * Redistributions in binary form must reproduce the above
+#       copyright notice, this list of conditions and the following
+#       disclaimer in the documentation and/or other materials
+#       provided with the distribution.
+
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDER “AS IS” AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+# OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+# PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+# TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+# THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+# SUCH DAMAGE.
+#
+# Includes modifications by joerick, which fall under the same license.
+
+from typing import Any
+
+
+def value_at_keypath(obj: Any, keypath: str) -> Any:
+  """
+  Returns value at given key path which follows dotted-path notation.
+
+    >>> x = dict(a=1, b=2, c=dict(d=3, e=4, f=[2,dict(x='foo', y='bar'),5]))
+    >>> assert value_at_keypath(x, 'a') == 1
+    >>> assert value_at_keypath(x, 'b') == 2
+    >>> assert value_at_keypath(x, 'c.d') == 3
+    >>> assert value_at_keypath(x, 'c.e') == 4
+    >>> assert value_at_keypath(x, 'c.f.0') == 2
+    >>> assert value_at_keypath(x, 'c.f.-1') == 5
+    >>> assert value_at_keypath(x, 'c.f.1.y') == 'bar'
+
+  """
+  for part in keypath.split('.'):
+    if isinstance(obj, dict):
+      obj = obj.get(part, {})
+    elif type(obj) in [tuple, list]:
+      obj = obj[int(part)]
+    else:
+      obj = getattr(obj, part, {})
+  return obj
+
+
+def set_value_at_keypath(obj: Any, keypath: str, val: Any):
+  """
+  Sets value at given key path which follows dotted-path notation.
+
+  Each part of the keypath must already exist in the target value
+  along the path.
+
+    >>> x = dict(a=1, b=2, c=dict(d=3, e=4, f=[2,dict(x='foo', y='bar'),5]))
+    >>> assert set_value_at_keypath(x, 'a', 2)
+    >>> assert value_at_keypath(x, 'a') == 2
+    >>> assert set_value_at_keypath(x, 'c.f.-1', 6)
+    >>> assert value_at_keypath(x, 'c.f.-1') == 6
+  """
+  parts = keypath.split('.')
+  for part in parts[:-1]:
+    if isinstance(obj, dict):
+      obj = obj[part]
+    elif type(obj) in [tuple, list]:
+      obj = obj[int(part)]
+    else:
+      obj = getattr(obj, part)
+  last_part = parts[-1]
+  if isinstance(obj, dict):
+    obj[last_part] = val
+  elif type(obj) in [tuple, list]:
+    obj[int(last_part)] = val
+  else:
+    setattr(obj, last_part, val)
+  return True

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,7 +3,7 @@ pytest
 flaky
 trio
 django  # used by middleware
-sphinx==4.0.2
+sphinx==4.2.0
 myst-parser==0.15.1
 furo==2021.6.18b36
 sphinxcontrib-programoutput==0.17
@@ -13,3 +13,4 @@ nox
 ipython
 numpy # used by an example
 pre-commit # used to run pre-commit hooks
+sphinx-autobuild==2021.3.14

--- a/test/low_level/test_context.py
+++ b/test/low_level/test_context.py
@@ -1,5 +1,8 @@
+from __future__ import annotations
+
 import contextvars
 import time
+from typing import Any
 
 import pytest
 
@@ -14,7 +17,9 @@ def test_context_type(setstatprofile):
         setstatprofile(None)
 
 
-profiler_context_var = contextvars.ContextVar("profiler_context_var", default=None)
+profiler_context_var: contextvars.ContextVar[Any] = contextvars.ContextVar(
+    "profiler_context_var", default=None
+)
 
 
 @parametrize_setstatprofile

--- a/test/low_level/test_setstatprofile.py
+++ b/test/low_level/test_setstatprofile.py
@@ -46,6 +46,6 @@ def test_internal_object_compatibility(setstatprofile):
     print(str(profile_state))
     print(profile_state)
     print(type(profile_state))
-    print(type(profile_state).__name__)
+    print(type(profile_state).__name__)  # type: ignore
 
     setstatprofile(None)

--- a/test/test_cmdline.py
+++ b/test/test_cmdline.py
@@ -5,27 +5,9 @@ from pathlib import Path
 
 import pytest
 
+from .util import BUSY_WAIT_SCRIPT
+
 # this script just does a busywait for 0.25 seconds.
-BUSY_WAIT_SCRIPT = """
-import time, sys
-
-def do_nothing():
-    pass
-
-def busy_wait(duration):
-    end_time = time.time() + duration
-
-    while time.time() < end_time:
-        do_nothing()
-
-def main():
-    print('sys.argv: ', sys.argv)
-    busy_wait(0.25)
-
-
-if __name__ == '__main__':
-    main()
-"""
 
 EXECUTION_DETAILS_SCRIPT = f"""
 #!{sys.executable}

--- a/test/test_cmdline_main.py
+++ b/test/test_cmdline_main.py
@@ -5,43 +5,99 @@ from unittest.mock import Mock, patch
 import pytest
 
 from pyinstrument.__main__ import main
+from pyinstrument.renderers.base import FrameRenderer
 from pyinstrument.renderers.console import ConsoleRenderer
 
 from .util import BUSY_WAIT_SCRIPT
+
+fake_renderer_instance = None
+
+
+class FakeRenderer(FrameRenderer):
+    def __init__(self, time=None, **kwargs):
+        self.time = time
+        super().__init__(**kwargs)
+        global fake_renderer_instance
+        fake_renderer_instance = self
+        print("instance")
+
+    def default_processors(self):
+        """
+        Return a list of processors that this renderer uses by default.
+        """
+        return []
+
+    def render(self, session) -> str:
+        return ""
 
 
 def test_renderer_option(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
     (tmp_path / "test_program.py").write_text(BUSY_WAIT_SCRIPT)
     monkeypatch.setattr(
-        "sys.argv", ["pyinstrument", "-p", "time=percent_of_total", "test_program.py"]
+        "sys.argv",
+        [
+            "pyinstrument",
+            "-r",
+            "test.test_cmdline_main.FakeRenderer",
+            "-p",
+            "time=percent_of_total",
+            "test_program.py",
+        ],
     )
     monkeypatch.chdir(tmp_path)
 
-    with patch(
-        "pyinstrument.__main__.renderers.ConsoleRenderer",
-        wraps=ConsoleRenderer,
-    ) as mock_renderer_class:
-        main()
+    global fake_renderer_instance
+    fake_renderer_instance = None
 
-    mock_renderer_class.assert_called_once()
-    args, kwargs = mock_renderer_class.call_args
-    assert kwargs["time"] == "percent_of_total"
+    main()
+
+    assert fake_renderer_instance is not None
+    assert fake_renderer_instance.time == "percent_of_total"
 
 
-def test_processor_renderer_option(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+def test_json_renderer_option(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
     (tmp_path / "test_program.py").write_text(BUSY_WAIT_SCRIPT)
     monkeypatch.setattr(
         "sys.argv",
-        ["pyinstrument", "-p", 'processor_options={"some_option": 44}', "test_program.py"],
+        [
+            "pyinstrument",
+            "-r",
+            "test.test_cmdline_main.FakeRenderer",
+            "-p",
+            'processor_options={"some_option": 44}',
+            "test_program.py",
+        ],
     )
     monkeypatch.chdir(tmp_path)
 
-    with patch(
-        "pyinstrument.__main__.renderers.ConsoleRenderer",
-        wraps=ConsoleRenderer,
-    ) as mock_renderer_class:
-        main()
+    global fake_renderer_instance
+    fake_renderer_instance = None
 
-    mock_renderer_class.assert_called_once()
-    args, kwargs = mock_renderer_class.call_args
-    assert kwargs["processor_options"]["some_option"] == 44
+    main()
+
+    assert fake_renderer_instance is not None
+    assert fake_renderer_instance.processor_options["some_option"] == 44
+
+
+def test_dotted_renderer_option(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+    (tmp_path / "test_program.py").write_text(BUSY_WAIT_SCRIPT)
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "pyinstrument",
+            "-r",
+            "test.test_cmdline_main.FakeRenderer",
+            "-p",
+            "processor_options.other_option=13",
+            "test_program.py",
+        ],
+    )
+    monkeypatch.chdir(tmp_path)
+
+    global fake_renderer_instance
+    fake_renderer_instance = None
+
+    main()
+
+    assert fake_renderer_instance is not None
+    assert fake_renderer_instance.processor_options["other_option"] == 13

--- a/test/test_cmdline_main.py
+++ b/test/test_cmdline_main.py
@@ -12,12 +12,34 @@ from .util import BUSY_WAIT_SCRIPT
 
 def test_renderer_option(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
     (tmp_path / "test_program.py").write_text(BUSY_WAIT_SCRIPT)
-    monkeypatch.setattr("sys.argv", ["pyinstrument", "-p", "show_percentages", "test_program.py"])
+    monkeypatch.setattr(
+        "sys.argv", ["pyinstrument", "-p", "time=percent_of_total", "test_program.py"]
+    )
     monkeypatch.chdir(tmp_path)
 
     with patch(
-        "pyinstrument.renderers.console.ConsoleRenderer", autospec=True
+        "pyinstrument.__main__.renderers.ConsoleRenderer",
+        wraps=ConsoleRenderer,
     ) as mock_renderer_class:
         main()
 
-    mock_renderer_class.assert_called_once_with(show_percentages=True)
+    mock_renderer_class.assert_called_once()
+    assert mock_renderer_class.call_args.kwargs["time"] == "percent_of_total"
+
+
+def test_processor_renderer_option(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+    (tmp_path / "test_program.py").write_text(BUSY_WAIT_SCRIPT)
+    monkeypatch.setattr(
+        "sys.argv",
+        ["pyinstrument", "-p", 'processor_options={"some_option": 44}', "test_program.py"],
+    )
+    monkeypatch.chdir(tmp_path)
+
+    with patch(
+        "pyinstrument.__main__.renderers.ConsoleRenderer",
+        wraps=ConsoleRenderer,
+    ) as mock_renderer_class:
+        main()
+
+    mock_renderer_class.assert_called_once()
+    assert mock_renderer_class.call_args.kwargs["processor_options"]["some_option"] == 44

--- a/test/test_cmdline_main.py
+++ b/test/test_cmdline_main.py
@@ -1,12 +1,9 @@
-import textwrap
 from pathlib import Path
-from unittest.mock import Mock, patch
 
 import pytest
 
 from pyinstrument.__main__ import main
 from pyinstrument.renderers.base import FrameRenderer
-from pyinstrument.renderers.console import ConsoleRenderer
 
 from .util import BUSY_WAIT_SCRIPT
 

--- a/test/test_cmdline_main.py
+++ b/test/test_cmdline_main.py
@@ -24,7 +24,8 @@ def test_renderer_option(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
         main()
 
     mock_renderer_class.assert_called_once()
-    assert mock_renderer_class.call_args.kwargs["time"] == "percent_of_total"
+    args, kwargs = mock_renderer_class.call_args
+    assert kwargs["time"] == "percent_of_total"
 
 
 def test_processor_renderer_option(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
@@ -42,4 +43,5 @@ def test_processor_renderer_option(monkeypatch: pytest.MonkeyPatch, tmp_path: Pa
         main()
 
     mock_renderer_class.assert_called_once()
-    assert mock_renderer_class.call_args.kwargs["processor_options"]["some_option"] == 44
+    args, kwargs = mock_renderer_class.call_args
+    assert kwargs["processor_options"]["some_option"] == 44

--- a/test/test_cmdline_main.py
+++ b/test/test_cmdline_main.py
@@ -1,0 +1,23 @@
+import textwrap
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+import pytest
+
+from pyinstrument.__main__ import main
+from pyinstrument.renderers.console import ConsoleRenderer
+
+from .util import BUSY_WAIT_SCRIPT
+
+
+def test_renderer_option(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+    (tmp_path / "test_program.py").write_text(BUSY_WAIT_SCRIPT)
+    monkeypatch.setattr("sys.argv", ["pyinstrument", "-p", "show_percentages", "test_program.py"])
+    monkeypatch.chdir(tmp_path)
+
+    with patch(
+        "pyinstrument.renderers.console.ConsoleRenderer", autospec=True
+    ) as mock_renderer_class:
+        main()
+
+    mock_renderer_class.assert_called_once_with(show_percentages=True)

--- a/test/util.py
+++ b/test/util.py
@@ -47,3 +47,25 @@ def first(iterator: Iterator[T]) -> Optional[T]:
         return next(iterator)
     except StopIteration:
         return None
+
+
+BUSY_WAIT_SCRIPT = """
+import time, sys
+
+def do_nothing():
+    pass
+
+def busy_wait(duration):
+    end_time = time.time() + duration
+
+    while time.time() < end_time:
+        do_nothing()
+
+def main():
+    print('sys.argv: ', sys.argv)
+    busy_wait(0.25)
+
+
+if __name__ == '__main__':
+    main()
+"""


### PR DESCRIPTION
Adds a command-line option `-p` `--render-option` that allows arbitrary setting of render options.

For example, to show percentages on the command line, you can do `pyinstrument -p time=percent_of_total myscript.py`.

Processor options can also be set, using a JSON dict form, like `pyinstrument -p 'processor_options={"filter_threshold": 0}' myscript.py`, or dotted form, like `pyinstrument -p processor_options.filter_threshold=0 myscript.py`

Closes #180 and closes #174 