### PR TITLE
3.11 frame support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11-dev"]
 
     steps:
     - uses: actions/checkout@v2

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ __pycache__/
 
 # C extensions
 *.so
+*.pyd
 
 # distribution
 dist/

--- a/pyinstrument/low_level/stat_profile.c
+++ b/pyinstrument/low_level/stat_profile.c
@@ -16,7 +16,7 @@
 #if PY_VERSION_HEX >= 0x030b0000 // Python 3.11.0
 #define PyFrame_GETBACK(f) PyFrame_GetBack(f)
 #else
-#define PyFrame_GETBACK(f) f->f_back
+#define PyFrame_GETBACK(f) (Py_XINCREF(f->f_back), f->f_back)
 #endif
 
 /*
@@ -303,9 +303,11 @@ profile(PyObject *op, PyFrameObject *frame, int what, PyObject *arg)
         }
 
         if (old_context_var_value != pState->last_context_var_value) {
-            PyFrameObject *context_change_frame;
-            if (what == WHAT_CALL && PyFrame_GETBACK(frame)) {
-                context_change_frame = PyFrame_GETBACK(frame);
+            PyFrameObject *context_change_frame; // borrowed reference
+            PyFrameObject *parent_frame = PyFrame_GETBACK(frame); // strong reference, maybe null
+
+            if (what == WHAT_CALL && parent_frame) {
+                context_change_frame = parent_frame;
             } else {
                 context_change_frame = frame;
             }
@@ -320,6 +322,7 @@ profile(PyObject *op, PyFrameObject *frame, int what, PyObject *arg)
             result = call_target(pState, context_change_frame, WHAT_CONTEXT_CHANGED, context_change_arg);
 
             Py_DECREF(context_change_arg);
+            Py_XDECREF(parent_frame);
 
             if (result == NULL) {
                 PyEval_SetProfile(NULL, NULL);

--- a/pyinstrument/low_level/stat_profile.c
+++ b/pyinstrument/low_level/stat_profile.c
@@ -13,6 +13,12 @@
 
 #endif
 
+#if PY_VERSION_HEX >= 0x030b0000 // Python 3.11.0
+#define PyFrame_GETBACK(f) PyFrame_GetBack(f)
+#else
+#define PyFrame_GETBACK(f) f->f_back
+#endif
+
 /*
 These timer functions are mostly stolen from timemodule.c
 */
@@ -298,8 +304,8 @@ profile(PyObject *op, PyFrameObject *frame, int what, PyObject *arg)
 
         if (old_context_var_value != pState->last_context_var_value) {
             PyFrameObject *context_change_frame;
-            if (what == WHAT_CALL && frame->f_back) {
-                context_change_frame = frame->f_back;
+            if (what == WHAT_CALL && PyFrame_GETBACK(frame)) {
+                context_change_frame = PyFrame_GETBACK(frame);
             } else {
                 context_change_frame = frame;
             }

--- a/pyinstrument/low_level/stat_profile.c
+++ b/pyinstrument/low_level/stat_profile.c
@@ -16,7 +16,12 @@
 #if PY_VERSION_HEX >= 0x030b0000 // Python 3.11.0
 #define PyFrame_GETBACK(f) PyFrame_GetBack(f)
 #else
-#define PyFrame_GETBACK(f) (Py_XINCREF(f->f_back), f->f_back)
+static PyFrameObject *
+_PyFrame_GetBack(PyFrameObject *frame) {
+    Py_XINCREF(frame->f_back);
+    return frame->f_back;
+}
+#define PyFrame_GETBACK(f) _PyFrame_GetBack(f)
 #endif
 
 /*

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -8,7 +8,8 @@ myst-parser==0.15.1
 furo==2021.6.18b36
 sphinxcontrib-programoutput==0.17
 pytest-asyncio==0.12.0  # pinned to an older version due to an incompatibility with flaky
-greenlet  # used by a test
+greenlet ; python_version < "3.11.0b1" # used by a test
+https://github.com/vstinner/greenlet/archive/refs/heads/1.x-py311.zip ; python_version >= "3.11.0b1"
 nox
 ipython
 numpy # used by an example


### PR DESCRIPTION
Fixes #187 

Fork of the 3.11 testing branch.

Adds a shim for getting f_back.

In 3.11 this can be fetched using a function. See https://docs.python.org/3.11/whatsnew/3.11.html#pyframeobject-3-11-hiding