### PR TITLE
Upgrade mention of MIDDLEWARE_CLASSES to newer MIDDLEWARE setting in Django docs

### DIFF
--- a/docs/guide.md
+++ b/docs/guide.md
@@ -125,7 +125,7 @@ To customize options, see `%%pyinstrument??`.
 ### Profile a web request in Django
 
 To profile Django web requests, add
-`pyinstrument.middleware.ProfilerMiddleware` to `MIDDLEWARE_CLASSES` in your
+`pyinstrument.middleware.ProfilerMiddleware` to `MIDDLEWARE` in your
 `settings.py`.
 
 Once installed, add `?profile` to the end of a request URL to activate the


### PR DESCRIPTION
I'm aware that the pyinstrument middleware is using `django.utils.deprecation.MiddlewareMixin` therefore is compatible with both `MIDDLEWARE` and the old `MIDDLEWARE_CLASSES`. However, since the `MIDDLEWARE_CLASSES` setting was officially deprecated since Django 1.10, this being mentioned in the docs might be a bit confusing to the user.

https://docs.djangoproject.com/en/1.11/ref/settings/#middleware-classes