### PR TITLE
Expose interval option in command-line interface

### DIFF
--- a/pyinstrument/__main__.py
+++ b/pyinstrument/__main__.py
@@ -218,6 +218,20 @@ def main():
         action="store_false",
         help="(text renderer only) force no color text output",
     )
+    parser.add_option(
+        "-i",
+        "--interval",
+        action="store",
+        type=float,
+        help=(
+            "Minimum time, in seconds, between each stack sample. Smaller values "
+            "allow resolving shorter duration function calls but conversely incur a "
+            "greater runtime and memory consumption overhead. For longer running "
+            "scripts, setting a larger interval can help control the rate at which "
+            "the memory required to store the stack samples increases."
+        ),
+        default=0.001,
+    )
 
     # parse the options
 
@@ -303,7 +317,7 @@ def main():
         # because it will always be capturing the whole program, we never want
         # any execution to be <out-of-context>, and it avoids duplicate
         # profiler errors.
-        profiler = Profiler(async_mode="disabled")
+        profiler = Profiler(interval=options.interval, async_mode="disabled")
 
         profiler.start()
 
@@ -567,6 +581,7 @@ class CommandLineOptions:
     color: bool | None
     renderer: str
     timeline: bool
+    interval: float
 
 
 if __name__ == "__main__":

--- a/test/test_cmdline.py
+++ b/test/test_cmdline.py
@@ -179,3 +179,19 @@ class TestCommandLine:
         output = subprocess.check_output([*pyinstrument_invocation, f"--load={session_file}"])
         assert "busy_wait" in str(output)
         assert "do_nothing" in str(output)
+
+    def test_interval(self, pyinstrument_invocation, tmp_path: Path):
+        busy_wait_py = tmp_path / "busy_wait.py"
+        busy_wait_py.write_text(BUSY_WAIT_SCRIPT)
+
+        output = subprocess.check_output(
+            [
+                *pyinstrument_invocation,
+                "--interval",
+                "0.005",
+                str(busy_wait_py),
+            ]
+        )
+
+        assert "busy_wait" in str(output)
+        assert "do_nothing" in str(output)

--- a/test/test_cmdline.py
+++ b/test/test_cmdline.py
@@ -188,7 +188,7 @@ class TestCommandLine:
             [
                 *pyinstrument_invocation,
                 "--interval",
-                "0.005",
+                "0.002",
                 str(busy_wait_py),
             ]
         )


### PR DESCRIPTION
Related to the discussion in #169, I've found that the memory overhead of using `pyinstrument` to profile long-running (several hours run time) scripts using the command-line interface with the default sampling interval of 0.001&thinsp;s can result in runs prematurely terminating with an out-of-memory error. Given there will be (tens of) millions of stack samples being recorded in this case, that there are issues with memory consumption in such cases is not surprising, but also this suggests a much longer sampling interval would be appropriate in such cases while still giving reasonable low-variance estimates. This PR exposes the existing `interval` argument to the `Profiler` class in the command-line interface to allow easier adjustment of the sampling interval without needing to use the Python interface directly.