### PR TITLE
Hide tracebackhidden frames

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,23 @@
+# See here for image contents: https://github.com/microsoft/vscode-dev-containers/tree/v0.238.0/containers/cpp/.devcontainer/base.Dockerfile
+
+# [Choice] Debian / Ubuntu version (use Debian 11, Ubuntu 18.04/22.04 on local arm64/Apple Silicon): debian-11, debian-10, ubuntu-22.04, ubuntu-20.04, ubuntu-18.04
+ARG VARIANT="bullseye"
+FROM mcr.microsoft.com/vscode/devcontainers/cpp:0-${VARIANT}
+
+# [Optional] Install CMake version different from what base image has already installed. 
+# CMake reinstall choices: none, 3.21.5, 3.22.2, or versions from https://cmake.org/download/
+ARG REINSTALL_CMAKE_VERSION_FROM_SOURCE="none"
+
+# Optionally install the cmake for vcpkg
+COPY ./reinstall-cmake.sh /tmp/
+RUN if [ "${REINSTALL_CMAKE_VERSION_FROM_SOURCE}" != "none" ]; then \
+        chmod +x /tmp/reinstall-cmake.sh && /tmp/reinstall-cmake.sh ${REINSTALL_CMAKE_VERSION_FROM_SOURCE}; \
+    fi \
+    && rm -f /tmp/reinstall-cmake.sh
+
+# [Optional] Uncomment this section to install additional vcpkg ports.
+# RUN su vscode -c "${VCPKG_ROOT}/vcpkg install <your-port-name-here>"
+
+# [Optional] Uncomment this section to install additional packages.
+# RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+#     && apt-get -y install --no-install-recommends <your-package-list-here>

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,46 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
+// https://github.com/microsoft/vscode-dev-containers/tree/v0.238.0/containers/cpp
+{
+	"name": "C++",
+	"build": {
+		"dockerfile": "Dockerfile",
+		// Update 'VARIANT' to pick an Debian / Ubuntu OS version: debian-11, debian-10, ubuntu-22.04, ubuntu-20.04, ubuntu-18.04
+		// Use Debian 11, Ubuntu 18.04 or Ubuntu 22.04 on local arm64/Apple Silicon
+		"args": { "VARIANT": "ubuntu-22.04" }
+	},
+	"runArgs": ["--cap-add=SYS_PTRACE", "--security-opt", "seccomp=unconfined"],
+
+	// Configure tool-specific properties.
+	"customizations": {
+		// Configure properties specific to VS Code.
+		"vscode": {
+			// Add the IDs of extensions you want installed when the container is created.
+			"extensions": [
+				"benjamin-simmonds.pythoncpp-debug",
+				"eamodio.gitlens",
+				"ms-python.python",
+				"ms-python.vscode-pylance",
+				"ms-vscode.cmake-tools",
+				"ms-vscode.cpptools",
+				"samuelcolvin.jinjahtml",
+				"xr0master.webstorm-intellij-darcula-theme"
+			]
+		}
+	},
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	// "postCreateCommand": "gcc -v",
+
+	// Comment out to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
+	"remoteUser": "vscode",
+	"features": {
+		"git": "latest",
+		"github-cli": "latest",
+		"sshd": "latest",
+		"node": "16",
+		"python": "3.10"
+	}
+}

--- a/.devcontainer/reinstall-cmake.sh
+++ b/.devcontainer/reinstall-cmake.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+#-------------------------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
+#-------------------------------------------------------------------------------------------------------------
+#
+set -e
+
+CMAKE_VERSION=${1:-"none"}
+
+if [ "${CMAKE_VERSION}" = "none" ]; then
+    echo "No CMake version specified, skipping CMake reinstallation"
+    exit 0
+fi
+
+# Cleanup temporary directory and associated files when exiting the script.
+cleanup() {
+    EXIT_CODE=$?
+    set +e
+    if [[ -n "${TMP_DIR}" ]]; then
+        echo "Executing cleanup of tmp files"
+        rm -Rf "${TMP_DIR}"
+    fi
+    exit $EXIT_CODE
+}
+trap cleanup EXIT
+
+
+echo "Installing CMake..."
+apt-get -y purge --auto-remove cmake
+mkdir -p /opt/cmake
+
+architecture=$(dpkg --print-architecture)
+case "${architecture}" in
+    arm64)
+        ARCH=aarch64 ;;
+    amd64)
+        ARCH=x86_64 ;;
+    *)
+        echo "Unsupported architecture ${architecture}."
+        exit 1
+        ;;
+esac
+
+CMAKE_BINARY_NAME="cmake-${CMAKE_VERSION}-linux-${ARCH}.sh"
+CMAKE_CHECKSUM_NAME="cmake-${CMAKE_VERSION}-SHA-256.txt"
+TMP_DIR=$(mktemp -d -t cmake-XXXXXXXXXX)
+
+echo "${TMP_DIR}"
+cd "${TMP_DIR}"
+
+curl -sSL "https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/${CMAKE_BINARY_NAME}" -O
+curl -sSL "https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/${CMAKE_CHECKSUM_NAME}" -O
+
+sha256sum -c --ignore-missing "${CMAKE_CHECKSUM_NAME}"
+sh "${TMP_DIR}/${CMAKE_BINARY_NAME}" --prefix=/opt/cmake --skip-license
+
+ln -s /opt/cmake/bin/cmake /usr/local/bin/cmake

--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,8 @@ build
 .pytest_cache
 
 # editor
+*.code-workspace
+.history
 .vscode
 
 # docs

--- a/pyinstrument/frame.py
+++ b/pyinstrument/frame.py
@@ -100,6 +100,10 @@ class BaseFrame:
         raise NotImplementedError()
 
     @property
+    def hidden(self) -> bool | None:
+        raise NotImplementedError()
+
+    @property
     def file_path_short(self) -> str | None:
         raise NotImplementedError()
 
@@ -199,6 +203,11 @@ class Frame(BaseFrame):
     def line_no(self) -> int | None:
         if self.identifier:
             return int(self.identifier.split("\x00")[2])
+
+    @property
+    def hidden(self) -> bool | None:
+        if self.identifier:
+            return bool(int(self.identifier.split("\x00")[3]))
 
     @property
     def file_path_short(self) -> str | None:
@@ -324,6 +333,11 @@ class DummyFrame(BaseFrame):
             return self.parent.line_no
 
     @property
+    def hidden(self):
+        if self.parent:
+            return self.parent.hidden
+
+    @property
     def file_path_short(self):
         return ""
 
@@ -377,7 +391,7 @@ class AwaitTimeFrame(DummyFrame):
         return "[await]"
 
 
-AWAIT_FRAME_IDENTIFIER = "[await]\x00<await>\x000"
+AWAIT_FRAME_IDENTIFIER = "[await]\x00<await>\x000\x000"
 
 
 class OutOfContextFrame(DummyFrame):
@@ -400,7 +414,7 @@ class OutOfContextFrame(DummyFrame):
         return "[out-of-context]"
 
 
-OUT_OF_CONTEXT_FRAME_IDENTIFIER = "[out-of-context]\x00<out-of-context>\x000"
+OUT_OF_CONTEXT_FRAME_IDENTIFIER = "[out-of-context]\x00<out-of-context>\x000\x000"
 
 
 class FrameGroup:

--- a/pyinstrument/low_level/stat_profile_python.py
+++ b/pyinstrument/low_level/stat_profile_python.py
@@ -41,12 +41,14 @@ class PythonStatProfiler:
 
             # 0x80 == CO_COROUTINE (i.e. defined with 'async def')
             if event == "return" and frame.f_code.co_flags & 0x80:
+                hidden = frame.f_locals.get("__tracebackhide__", False)
                 self.await_stack.append(
-                    "%s\x00%s\x00%i"
+                    "%s\x00%s\x00%i\x00%i"
                     % (
                         frame.f_code.co_name,
                         frame.f_code.co_filename,
                         frame.f_code.co_firstlineno,
+                        hidden,
                     )
                 )
             else:

--- a/pyinstrument/renderers/console.py
+++ b/pyinstrument/renderers/console.py
@@ -157,6 +157,7 @@ class ConsoleRenderer(FrameRenderer):
     def default_processors(self) -> ProcessorList:
         return [
             processors.remove_importlib,
+            processors.remove_hidden,
             processors.merge_consecutive_self_time,
             processors.aggregate_repeated_calls,
             processors.group_library_frames_processor,

--- a/pyinstrument/renderers/html.py
+++ b/pyinstrument/renderers/html.py
@@ -92,6 +92,7 @@ class HTMLRenderer(FrameRenderer):
     def default_processors(self) -> ProcessorList:
         return [
             processors.remove_importlib,
+        	processors.remove_hidden,
             processors.merge_consecutive_self_time,
             processors.aggregate_repeated_calls,
             processors.group_library_frames_processor,

--- a/pyinstrument/renderers/jsonrenderer.py
+++ b/pyinstrument/renderers/jsonrenderer.py
@@ -77,6 +77,7 @@ class JSONRenderer(FrameRenderer):
     def default_processors(self) -> ProcessorList:
         return [
             processors.remove_importlib,
+        	processors.remove_hidden,
             processors.merge_consecutive_self_time,
             processors.aggregate_repeated_calls,
             processors.group_library_frames_processor,

--- a/pyinstrument/renderers/speedscope.py
+++ b/pyinstrument/renderers/speedscope.py
@@ -230,6 +230,7 @@ class SpeedscopeRenderer(FrameRenderer):
         """
         return [
             processors.remove_importlib,
+        	processors.remove_hidden,
             processors.merge_consecutive_self_time,
             processors.group_library_frames_processor,
             processors.remove_unnecessary_self_time_nodes,

--- a/test/test_processors.py
+++ b/test/test_processors.py
@@ -10,6 +10,7 @@ all_processors = [
     processors.group_library_frames_processor,
     processors.merge_consecutive_self_time,
     processors.remove_importlib,
+    processors.remove_hidden,
     processors.remove_unnecessary_self_time_nodes,
     processors.remove_irrelevant_nodes,
 ]


### PR DESCRIPTION
Fixes #190

This adds a generic "hidden" property to the frame record objects. Currently this is only set to true if the frame has `__tracebackhide__==True` in it's locals dict, as discussed in #190. Also adds a default processor that hides any frames with `.hidden==True`.

Not sure if this is the right approach overall, and very not sure if the changes to the c extension were the right ones. @joerick Feedback would be much appreciated.

I also added the `.devcontainer` dir that I came up with while developing these changes. This allows for developing pyinstrument in a container when using vscode (and maybe other ides?). Specifically, this allowed me to do stuff like simultaneously debug the python and c extension code (even though I'm developing on a mac), which was super useful. Dunno if you want this in the repo, I can remove it if you prefer.