### PR TITLE
Added asyncio support to cell magic

### DIFF
--- a/pyinstrument/magic/magic.py
+++ b/pyinstrument/magic/magic.py
@@ -42,7 +42,7 @@ class PyinstrumentMagic(Magics):
     )
     @argument(
         "--async_mode",
-        default="enabled",
+        default="disabled",
         help="Configures how this Profiler tracks time in a program that uses async/await. See: https://pyinstrument.readthedocs.io/en/latest/reference.html#pyinstrument.Profiler.async_mode",
     )
     @argument(


### PR DESCRIPTION
The current version of the pyinstrument magic does not support async code at all. It doesn't matter whether you have `async_mode` set to `enabled` or `disabled`, it will break because it will try to run in a new event loop.

This seems to be a known upstream issue but I don't think anyone is working on it: https://github.com/ipython/ipython/issues/11314

This modification is certainly very hacky, but it's working quite well for me and I don't foresee any issues with it.
If it does cause issues, it doesn't do anything when using `--async_mode=disabled` :)