### PR TITLE
skip hidden frames

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,23 @@
+# See here for image contents: https://github.com/microsoft/vscode-dev-containers/tree/v0.238.0/containers/cpp/.devcontainer/base.Dockerfile
+
+# [Choice] Debian / Ubuntu version (use Debian 11, Ubuntu 18.04/22.04 on local arm64/Apple Silicon): debian-11, debian-10, ubuntu-22.04, ubuntu-20.04, ubuntu-18.04
+ARG VARIANT="bullseye"
+FROM mcr.microsoft.com/vscode/devcontainers/cpp:0-${VARIANT}
+
+# [Optional] Install CMake version different from what base image has already installed. 
+# CMake reinstall choices: none, 3.21.5, 3.22.2, or versions from https://cmake.org/download/
+ARG REINSTALL_CMAKE_VERSION_FROM_SOURCE="none"
+
+# Optionally install the cmake for vcpkg
+COPY ./reinstall-cmake.sh /tmp/
+RUN if [ "${REINSTALL_CMAKE_VERSION_FROM_SOURCE}" != "none" ]; then \
+        chmod +x /tmp/reinstall-cmake.sh && /tmp/reinstall-cmake.sh ${REINSTALL_CMAKE_VERSION_FROM_SOURCE}; \
+    fi \
+    && rm -f /tmp/reinstall-cmake.sh
+
+# [Optional] Uncomment this section to install additional vcpkg ports.
+# RUN su vscode -c "${VCPKG_ROOT}/vcpkg install <your-port-name-here>"
+
+# [Optional] Uncomment this section to install additional packages.
+# RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+#     && apt-get -y install --no-install-recommends <your-package-list-here>

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -4,7 +4,7 @@
 ARG VARIANT="bullseye"
 FROM mcr.microsoft.com/vscode/devcontainers/cpp:0-${VARIANT}
 
-# [Optional] Install CMake version different from what base image has already installed. 
+# [Optional] Install CMake version different from what base image has already installed.
 # CMake reinstall choices: none, 3.21.5, 3.22.2, or versions from https://cmake.org/download/
 ARG REINSTALL_CMAKE_VERSION_FROM_SOURCE="none"
 

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,46 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
+// https://github.com/microsoft/vscode-dev-containers/tree/v0.238.0/containers/cpp
+{
+	"name": "C++",
+	"build": {
+		"dockerfile": "Dockerfile",
+		// Update 'VARIANT' to pick an Debian / Ubuntu OS version: debian-11, debian-10, ubuntu-22.04, ubuntu-20.04, ubuntu-18.04
+		// Use Debian 11, Ubuntu 18.04 or Ubuntu 22.04 on local arm64/Apple Silicon
+		"args": { "VARIANT": "ubuntu-22.04" }
+	},
+	"runArgs": ["--cap-add=SYS_PTRACE", "--security-opt", "seccomp=unconfined"],
+
+	// Configure tool-specific properties.
+	"customizations": {
+		// Configure properties specific to VS Code.
+		"vscode": {
+			// Add the IDs of extensions you want installed when the container is created.
+			"extensions": [
+				"benjamin-simmonds.pythoncpp-debug",
+				"eamodio.gitlens",
+				"ms-python.python",
+				"ms-python.vscode-pylance",
+				"ms-vscode.cmake-tools",
+				"ms-vscode.cpptools",
+				"samuelcolvin.jinjahtml",
+				"xr0master.webstorm-intellij-darcula-theme"
+			]
+		}
+	},
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	// "postCreateCommand": "gcc -v",
+
+	// Comment out to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
+	"remoteUser": "vscode",
+	"features": {
+		"git": "latest",
+		"github-cli": "latest",
+		"sshd": "latest",
+		"node": "16",
+		"python": "3.10"
+	}
+}

--- a/.devcontainer/reinstall-cmake.sh
+++ b/.devcontainer/reinstall-cmake.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+#-------------------------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
+#-------------------------------------------------------------------------------------------------------------
+#
+set -e
+
+CMAKE_VERSION=${1:-"none"}
+
+if [ "${CMAKE_VERSION}" = "none" ]; then
+    echo "No CMake version specified, skipping CMake reinstallation"
+    exit 0
+fi
+
+# Cleanup temporary directory and associated files when exiting the script.
+cleanup() {
+    EXIT_CODE=$?
+    set +e
+    if [[ -n "${TMP_DIR}" ]]; then
+        echo "Executing cleanup of tmp files"
+        rm -Rf "${TMP_DIR}"
+    fi
+    exit $EXIT_CODE
+}
+trap cleanup EXIT
+
+
+echo "Installing CMake..."
+apt-get -y purge --auto-remove cmake
+mkdir -p /opt/cmake
+
+architecture=$(dpkg --print-architecture)
+case "${architecture}" in
+    arm64)
+        ARCH=aarch64 ;;
+    amd64)
+        ARCH=x86_64 ;;
+    *)
+        echo "Unsupported architecture ${architecture}."
+        exit 1
+        ;;
+esac
+
+CMAKE_BINARY_NAME="cmake-${CMAKE_VERSION}-linux-${ARCH}.sh"
+CMAKE_CHECKSUM_NAME="cmake-${CMAKE_VERSION}-SHA-256.txt"
+TMP_DIR=$(mktemp -d -t cmake-XXXXXXXXXX)
+
+echo "${TMP_DIR}"
+cd "${TMP_DIR}"
+
+curl -sSL "https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/${CMAKE_BINARY_NAME}" -O
+curl -sSL "https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/${CMAKE_CHECKSUM_NAME}" -O
+
+sha256sum -c --ignore-missing "${CMAKE_CHECKSUM_NAME}"
+sh "${TMP_DIR}/${CMAKE_BINARY_NAME}" --prefix=/opt/cmake --skip-license
+
+ln -s /opt/cmake/bin/cmake /usr/local/bin/cmake

--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,8 @@ build
 .pytest_cache
 
 # editor
+*.code-workspace
+.history
 .vscode
 
 # docs

--- a/pyinstrument/frame.py
+++ b/pyinstrument/frame.py
@@ -142,6 +142,11 @@ class Frame:
             return int(self._identifier_parts[2])
 
     @property
+    def hidden(self) -> int | None:
+        if len(self._identifier_parts) > 3:
+            return int(self._identifier_parts[3])
+
+    @property
     def file_path_short(self) -> str | None:
         """Return the path resolved against the closest entry in sys.path"""
         if self.is_synthetic and self.parent:

--- a/pyinstrument/frame.py
+++ b/pyinstrument/frame.py
@@ -8,6 +8,7 @@ from typing import Sequence
 
 from pyinstrument.frame_info import (
     ATTRIBUTE_MARKER_CLASS_NAME,
+    ATTRIBUTE_MARKER_FRAME_HIDDEN,
     frame_info_get_identifier,
     parse_frame_info,
 )
@@ -140,11 +141,6 @@ class Frame:
     def line_no(self) -> int | None:
         if len(self._identifier_parts) > 2:
             return int(self._identifier_parts[2])
-
-    @property
-    def hidden(self) -> int | None:
-        if len(self._identifier_parts) > 3:
-            return int(self._identifier_parts[3])
 
     @property
     def file_path_short(self) -> str | None:
@@ -292,8 +288,14 @@ class Frame:
         return top_attribute[1:]
 
     @property
-    def class_name(self):
+    def class_name(self) -> str | None:
         return self.get_attribute_value(ATTRIBUTE_MARKER_CLASS_NAME)
+
+    @property
+    def hidden(self) -> int | None:
+        hidden = self.get_attribute_value(ATTRIBUTE_MARKER_FRAME_HIDDEN)
+
+        return None if hidden is None else int(hidden)
 
     def self_check(self, recursive: bool = True) -> None:
         """

--- a/pyinstrument/frame.py
+++ b/pyinstrument/frame.py
@@ -8,7 +8,7 @@ from typing import Sequence
 
 from pyinstrument.frame_info import (
     ATTRIBUTE_MARKER_CLASS_NAME,
-    ATTRIBUTE_MARKER_FRAME_TRACEBACKHIDE,
+    ATTRIBUTE_MARKER_TRACEBACKHIDE,
     frame_info_get_identifier,
     parse_frame_info,
 )
@@ -296,7 +296,7 @@ class Frame:
         """
         Returns whether this frame has a `__tracebackhide__` variable.
         """
-        return self.get_attribute_value(ATTRIBUTE_MARKER_FRAME_TRACEBACKHIDE) == "1"
+        return self.get_attribute_value(ATTRIBUTE_MARKER_TRACEBACKHIDE) == "1"
 
     def self_check(self, recursive: bool = True) -> None:
         """

--- a/pyinstrument/frame.py
+++ b/pyinstrument/frame.py
@@ -8,7 +8,7 @@ from typing import Sequence
 
 from pyinstrument.frame_info import (
     ATTRIBUTE_MARKER_CLASS_NAME,
-    ATTRIBUTE_MARKER_FRAME_HIDDEN,
+    ATTRIBUTE_MARKER_FRAME_TRACEBACKHIDE,
     frame_info_get_identifier,
     parse_frame_info,
 )
@@ -292,10 +292,11 @@ class Frame:
         return self.get_attribute_value(ATTRIBUTE_MARKER_CLASS_NAME)
 
     @property
-    def hidden(self) -> int | None:
-        hidden = self.get_attribute_value(ATTRIBUTE_MARKER_FRAME_HIDDEN)
-
-        return None if hidden is None else int(hidden)
+    def has_tracebackhide(self) -> bool:
+        """
+        Returns whether this frame has a `__tracebackhide__` variable.
+        """
+        return self.get_attribute_value(ATTRIBUTE_MARKER_FRAME_TRACEBACKHIDE) == "1"
 
     def self_check(self, recursive: bool = True) -> None:
         """

--- a/pyinstrument/frame_info.py
+++ b/pyinstrument/frame_info.py
@@ -8,7 +8,7 @@ ATTRIBUTES_SEP = "\x01"
 
 ATTRIBUTE_MARKER_CLASS_NAME = "c"
 ATTRIBUTE_MARKER_LINE_NUMBER = "l"
-ATTRIBUTE_MARKER_FRAME_TRACEBACKHIDE = "h"
+ATTRIBUTE_MARKER_TRACEBACKHIDE = "h"
 
 
 def parse_frame_info(frame_info: str) -> Tuple[str, List[str]]:

--- a/pyinstrument/frame_info.py
+++ b/pyinstrument/frame_info.py
@@ -8,7 +8,7 @@ ATTRIBUTES_SEP = "\x01"
 
 ATTRIBUTE_MARKER_CLASS_NAME = "c"
 ATTRIBUTE_MARKER_LINE_NUMBER = "l"
-ATTRIBUTE_MARKER_FRAME_HIDDEN = "h"
+ATTRIBUTE_MARKER_FRAME_TRACEBACKHIDE = "h"
 
 
 def parse_frame_info(frame_info: str) -> Tuple[str, List[str]]:

--- a/pyinstrument/frame_info.py
+++ b/pyinstrument/frame_info.py
@@ -8,6 +8,7 @@ ATTRIBUTES_SEP = "\x01"
 
 ATTRIBUTE_MARKER_CLASS_NAME = "c"
 ATTRIBUTE_MARKER_LINE_NUMBER = "l"
+ATTRIBUTE_MARKER_FRAME_HIDDEN = "h"
 
 
 def parse_frame_info(frame_info: str) -> Tuple[str, List[str]]:

--- a/pyinstrument/low_level/stat_profile.c
+++ b/pyinstrument/low_level/stat_profile.c
@@ -476,7 +476,7 @@ _get_class_name_of_frame(PyFrameObject *frame, PyCodeObject *code) {
  */
 static const int
 _get_tracebackhide(PyFrameObject *frame, PyCodeObject *code) {
-    if (code->co_argcount < 1) {
+    if (code->co_nlocals < 1) {
         return 0;
     }
 

--- a/pyinstrument/low_level/stat_profile.c
+++ b/pyinstrument/low_level/stat_profile.c
@@ -521,14 +521,14 @@ _get_frame_info(PyFrameObject *frame) {
     PyObject *frame_hidden_attribute;
 
     int tracebackhide = _get_tracebackhide(frame, code);
-    if (tracebackhide < 0) {
+    if (tracebackhide <= 0) {
         frame_hidden_attribute = PyUnicode_New(0, 127);
     } else {
         frame_hidden_attribute = PyUnicode_FromFormat(
-            "%c%c%d",
+            "%c%c%c",
             1,
             'h', // 'h' char denotes 'frame hidden'
-            tracebackhide
+            '1' // '1' char denotes 'true'
         );
     }
 

--- a/pyinstrument/low_level/stat_profile_python.py
+++ b/pyinstrument/low_level/stat_profile_python.py
@@ -79,10 +79,12 @@ def setstatprofile(
 
 
 def get_frame_info(frame: types.FrameType) -> str:
-    frame_info = "%s\x00%s\x00%i" % (
+    hidden = frame.f_locals.get("__tracebackhide__", False)
+    frame_info = "%s\x00%s\x00%i\x00%i" % (
         frame.f_code.co_name,
         frame.f_code.co_filename,
         frame.f_code.co_firstlineno,
+        hidden,
     )
 
     class_name = None

--- a/pyinstrument/low_level/stat_profile_python.py
+++ b/pyinstrument/low_level/stat_profile_python.py
@@ -104,7 +104,7 @@ def get_frame_info(frame: types.FrameType) -> str:
     if frame.f_lineno is not None:
         frame_info += "\x01l%i" % frame.f_lineno
 
-    if frame_hidden is not None:
+    if frame_hidden:
         frame_info += "\x01h%i" % frame_hidden
 
     return frame_info

--- a/pyinstrument/low_level/stat_profile_python.py
+++ b/pyinstrument/low_level/stat_profile_python.py
@@ -79,12 +79,10 @@ def setstatprofile(
 
 
 def get_frame_info(frame: types.FrameType) -> str:
-    hidden = frame.f_locals.get("__tracebackhide__", False)
-    frame_info = "%s\x00%s\x00%i\x00%i" % (
+    frame_info = "%s\x00%s\x00%i" % (
         frame.f_code.co_name,
         frame.f_code.co_filename,
         frame.f_code.co_firstlineno,
-        hidden,
     )
 
     class_name = None
@@ -98,10 +96,15 @@ def get_frame_info(frame: types.FrameType) -> str:
         if cls and hasattr(cls, "__qualname__"):
             class_name = cls.__qualname__
 
+    frame_hidden = "__tracebackhide__" in frame.f_locals
+
     if class_name:
         frame_info += "\x01c%s" % class_name
 
     if frame.f_lineno is not None:
         frame_info += "\x01l%i" % frame.f_lineno
+
+    if frame_hidden is not None:
+        frame_info += "\x01h%i" % frame_hidden
 
     return frame_info

--- a/pyinstrument/processors.py
+++ b/pyinstrument/processors.py
@@ -37,21 +37,24 @@ def remove_importlib(frame: Frame | None, options: ProcessorOptions) -> Frame | 
 
     return frame
 
-def remove_hidden(frame: Frame | None, options: ProcessorOptions) -> Frame | None:
+
+def remove_tracebackhide(frame: Frame | None, options: ProcessorOptions) -> Frame | None:
     """
-    Removes hidden (eg __tracebackhide__==True) frames that clutter the output.
+    Removes frames that have set a local `__tracebackhide__` (e.g.
+    `__tracebackhide__ = True`), to hide them from the output.
     """
     if frame is None:
         return None
 
     for child in frame.children:
-        remove_hidden(child, options=options)
+        remove_tracebackhide(child, options=options)
 
-        if child.hidden:
+        if child.has_tracebackhide:
             # remove this node, moving the self_time and children up to the parent
             delete_frame_from_tree(child, replace_with="children")
 
     return frame
+
 
 def aggregate_repeated_calls(frame: Frame | None, options: ProcessorOptions) -> Frame | None:
     """

--- a/pyinstrument/processors.py
+++ b/pyinstrument/processors.py
@@ -37,6 +37,21 @@ def remove_importlib(frame: Frame | None, options: ProcessorOptions) -> Frame | 
 
     return frame
 
+def remove_hidden(frame: Frame | None, options: ProcessorOptions) -> Frame | None:
+    """
+    Removes hidden (eg __tracebackhide__==True) frames that clutter the output.
+    """
+    if frame is None:
+        return None
+
+    for child in frame.children:
+        remove_hidden(child, options=options)
+
+        if child.hidden:
+            # remove this node, moving the self_time and children up to the parent
+            delete_frame_from_tree(child, replace_with="children")
+
+    return frame
 
 def aggregate_repeated_calls(frame: Frame | None, options: ProcessorOptions) -> Frame | None:
     """

--- a/pyinstrument/renderers/console.py
+++ b/pyinstrument/renderers/console.py
@@ -162,7 +162,7 @@ class ConsoleRenderer(FrameRenderer):
     def default_processors(self) -> ProcessorList:
         return [
             processors.remove_importlib,
-            processors.remove_hidden,
+            processors.remove_tracebackhide,
             processors.merge_consecutive_self_time,
             processors.aggregate_repeated_calls,
             processors.group_library_frames_processor,

--- a/pyinstrument/renderers/console.py
+++ b/pyinstrument/renderers/console.py
@@ -162,6 +162,7 @@ class ConsoleRenderer(FrameRenderer):
     def default_processors(self) -> ProcessorList:
         return [
             processors.remove_importlib,
+            processors.remove_hidden,
             processors.merge_consecutive_self_time,
             processors.aggregate_repeated_calls,
             processors.group_library_frames_processor,

--- a/pyinstrument/renderers/html.py
+++ b/pyinstrument/renderers/html.py
@@ -92,7 +92,7 @@ class HTMLRenderer(FrameRenderer):
     def default_processors(self) -> ProcessorList:
         return [
             processors.remove_importlib,
-            processors.remove_hidden,
+            processors.remove_tracebackhide,
             processors.merge_consecutive_self_time,
             processors.aggregate_repeated_calls,
             processors.group_library_frames_processor,

--- a/pyinstrument/renderers/html.py
+++ b/pyinstrument/renderers/html.py
@@ -92,6 +92,7 @@ class HTMLRenderer(FrameRenderer):
     def default_processors(self) -> ProcessorList:
         return [
             processors.remove_importlib,
+            processors.remove_hidden,
             processors.merge_consecutive_self_time,
             processors.aggregate_repeated_calls,
             processors.group_library_frames_processor,

--- a/pyinstrument/renderers/jsonrenderer.py
+++ b/pyinstrument/renderers/jsonrenderer.py
@@ -80,6 +80,7 @@ class JSONRenderer(FrameRenderer):
     def default_processors(self) -> ProcessorList:
         return [
             processors.remove_importlib,
+            processors.remove_hidden,
             processors.merge_consecutive_self_time,
             processors.aggregate_repeated_calls,
             processors.group_library_frames_processor,

--- a/pyinstrument/renderers/jsonrenderer.py
+++ b/pyinstrument/renderers/jsonrenderer.py
@@ -80,7 +80,7 @@ class JSONRenderer(FrameRenderer):
     def default_processors(self) -> ProcessorList:
         return [
             processors.remove_importlib,
-            processors.remove_hidden,
+            processors.remove_tracebackhide,
             processors.merge_consecutive_self_time,
             processors.aggregate_repeated_calls,
             processors.group_library_frames_processor,

--- a/pyinstrument/renderers/speedscope.py
+++ b/pyinstrument/renderers/speedscope.py
@@ -234,7 +234,7 @@ class SpeedscopeRenderer(FrameRenderer):
         """
         return [
             processors.remove_importlib,
-            processors.remove_hidden,
+            processors.remove_tracebackhide,
             processors.merge_consecutive_self_time,
             processors.group_library_frames_processor,
             processors.remove_unnecessary_self_time_nodes,

--- a/pyinstrument/renderers/speedscope.py
+++ b/pyinstrument/renderers/speedscope.py
@@ -234,6 +234,7 @@ class SpeedscopeRenderer(FrameRenderer):
         """
         return [
             processors.remove_importlib,
+            processors.remove_hidden,
             processors.merge_consecutive_self_time,
             processors.group_library_frames_processor,
             processors.remove_unnecessary_self_time_nodes,

--- a/test/low_level/test_frame_info.py
+++ b/test/low_level/test_frame_info.py
@@ -6,11 +6,15 @@ from pyinstrument.low_level import stat_profile_python
 
 class AClass:
     def get_frame_info_for_a_method(self, getter_function):
+        __tracebackhide__ = True
+
         frame = inspect.currentframe()
         assert frame
         return getter_function(frame)
 
     def get_frame_info_with_cell_variable(self, getter_function):
+        __tracebackhide__ = True
+
         frame = inspect.currentframe()
         assert frame
 
@@ -45,6 +49,7 @@ def test_frame_info_with_classes():
     ]
 
     for test_function in test_functions:
-        assert test_function(stat_profile_c.get_frame_info) == test_function(
-            stat_profile_python.get_frame_info
-        )
+        c_frame_info = test_function(stat_profile_c.get_frame_info)
+        py_frame_info = test_function(stat_profile_python.get_frame_info)
+
+        assert c_frame_info == py_frame_info

--- a/test/low_level/test_frame_info.py
+++ b/test/low_level/test_frame_info.py
@@ -13,16 +13,19 @@ class AClass:
         return getter_function(frame)
 
     def get_frame_info_with_cell_variable(self, getter_function):
-        __tracebackhide__ = True
-
-        frame = inspect.currentframe()
-        assert frame
-
         def an_inner_function():
+            __tracebackhide__ = True
+
+            frame = inspect.currentframe()
+            assert frame
+
             # reference self to make it a cell variable
             if self:
                 pass
 
+            return frame
+
+        frame = an_inner_function()
         return getter_function(frame)
 
     @classmethod
@@ -33,6 +36,8 @@ class AClass:
 
 
 def test_frame_info():
+    __tracebackhide__ = True
+
     frame = inspect.currentframe()
 
     assert frame

--- a/test/low_level/test_frame_info.py
+++ b/test/low_level/test_frame_info.py
@@ -6,26 +6,19 @@ from pyinstrument.low_level import stat_profile_python
 
 class AClass:
     def get_frame_info_for_a_method(self, getter_function):
-        __tracebackhide__ = True
-
         frame = inspect.currentframe()
         assert frame
         return getter_function(frame)
 
     def get_frame_info_with_cell_variable(self, getter_function):
+        frame = inspect.currentframe()
+        assert frame
+
         def an_inner_function():
-            __tracebackhide__ = True
-
-            frame = inspect.currentframe()
-            assert frame
-
             # reference self to make it a cell variable
             if self:
                 pass
 
-            return frame
-
-        frame = an_inner_function()
         return getter_function(frame)
 
     @classmethod
@@ -36,7 +29,29 @@ class AClass:
 
 
 def test_frame_info():
+    frame = inspect.currentframe()
+
+    assert frame
+    assert stat_profile_c.get_frame_info(frame) == stat_profile_python.get_frame_info(frame)
+
+
+def test_frame_info_hide_true():
     __tracebackhide__ = True
+
+    frame = inspect.currentframe()
+
+    assert frame
+    assert stat_profile_c.get_frame_info(frame) == stat_profile_python.get_frame_info(frame)
+
+
+def test_frame_info_hide_false():
+    """to avoid calling FastToLocals on the c side,
+    __tracebackhide__ = True
+    and
+    __tracebackhide__ = False
+    are treated the same. All that matters is that the var is defined
+    """
+    __tracebackhide__ = False
 
     frame = inspect.currentframe()
 

--- a/test/test_processors.py
+++ b/test/test_processors.py
@@ -11,7 +11,7 @@ ALL_PROCESSORS = [
     processors.group_library_frames_processor,
     processors.merge_consecutive_self_time,
     processors.remove_importlib,
-    processors.remove_hidden,
+    processors.remove_tracebackhide,
     processors.remove_unnecessary_self_time_nodes,
     processors.remove_irrelevant_nodes,
 ]
@@ -117,7 +117,7 @@ def test_remove_hidden():
     assert frame.total_self_time == 0.0
     assert frame.time == approx(0.5)
 
-    frame = processors.remove_hidden(frame, options={})
+    frame = processors.remove_tracebackhide(frame, options={})
     assert frame
     frame.self_check()
 


### PR DESCRIPTION
fixes #190

updated version of #211. It was easier to just start a new PR than it was to resolve the conflicts after the py 3.11 updates. From the original PR:

> This adds a generic "hidden" property to the frame record objects. Currently this is only set to true if the frame has __tracebackhide__==True in it's locals dict, as discussed in https://github.com/joerick/pyinstrument/issues/190. Also adds a default processor that hides any frames with .hidden==True.
>
> Not sure if this is the right approach overall, and very not sure if the changes to the c extension were the right ones. @joerick Feedback would be much appreciated.
>
> I also added the .devcontainer dir that I came up with while developing these changes. This allows for developing pyinstrument in a container when using vscode (and maybe other ides?). Specifically, this allowed me to do stuff like simultaneously debug the python and c extension code (even though I'm developing on a mac), which was super useful. Dunno if you want this in the repo, I can remove it if you prefer.