### PR TITLE
Fix show all

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -39,8 +39,9 @@
 	"features": {
 		"git": "latest",
 		"github-cli": "latest",
-		"sshd": "latest",
 		"node": "16",
-		"python": "3.10"
+		"python": "3.10",
+		"sshd": "latest",
+		"ghcr.io/guiyomh/features/vim": "0.0.1"
 	}
 }

--- a/pyinstrument/__main__.py
+++ b/pyinstrument/__main__.py
@@ -392,13 +392,10 @@ def compute_render_options(
 
         render_options.update({"unicode": unicode, "color": color})
 
-    # add in any top-level options
-    for opt in (
-        "show_all",
-        "timeline",
-    ):
-        if getattr(options, opt):
-            render_options[opt] = True
+    if options.timeline:
+        render_options["timeline"] = True
+    if options.show_all:
+        render_options["show_all"] = True
 
     # apply user options
     if options.render_options is not None:

--- a/pyinstrument/__main__.py
+++ b/pyinstrument/__main__.py
@@ -392,8 +392,13 @@ def compute_render_options(
 
         render_options.update({"unicode": unicode, "color": color})
 
-    if options.timeline:
-        render_options["timeline"] = True
+    # add in any top-level options
+    for opt in (
+        "show_all",
+        "timeline",
+    ):
+        if getattr(options, opt):
+            render_options[opt] = True
 
     # apply user options
     if options.render_options is not None:

--- a/pyinstrument/processors.py
+++ b/pyinstrument/processors.py
@@ -86,8 +86,6 @@ def group_library_frames_processor(frame: Frame | None, options: ProcessorOption
     def should_be_hidden(frame: Frame):
         frame_file_path = frame.file_path or ""
 
-        # should_show = False
-        # should_hide = True
         should_show = (show_regex is not None) and re.match(show_regex, frame_file_path)
         should_hide = (hide_regex is not None) and re.match(hide_regex, frame_file_path)
 

--- a/pyinstrument/renderers/base.py
+++ b/pyinstrument/renderers/base.py
@@ -68,7 +68,17 @@ class FrameRenderer(Renderer):
         self.processor_options = processor_options or {}
 
         if show_all:
-            self.processors.remove(processors.group_library_frames_processor)
+            for p in (
+                processors.group_library_frames_processor,
+                processors.remove_importlib,
+                processors.remove_irrelevant_nodes,
+                processors.remove_tracebackhide,
+                processors.remove_unnecessary_self_time_nodes,
+
+                # always hide the outer pyinstrument cruft frames
+                # processors.remove_first_pyinstrument_frames_processor,
+            ):
+                self.processors.remove(p)
         if timeline:
             self.processors.remove(processors.aggregate_repeated_calls)
 

--- a/pyinstrument/renderers/base.py
+++ b/pyinstrument/renderers/base.py
@@ -73,7 +73,9 @@ class FrameRenderer(Renderer):
                 processors.remove_importlib,
                 processors.remove_irrelevant_nodes,
                 processors.remove_tracebackhide,
-                processors.remove_unnecessary_self_time_nodes,
+
+                # always hide the inner pyinstrument cruft frames
+                # processors.remove_unnecessary_self_time_nodes,
 
                 # always hide the outer pyinstrument cruft frames
                 # processors.remove_first_pyinstrument_frames_processor,


### PR DESCRIPTION
fixes #223

This PR address the hide/show bug that @joerick pointed out in #223. I'll open separate issues for the other discussed in that issue.

This turned out to be more complex than I would have thought for rendering related junk. In part this was because the `--show-all` cmd line option was initially busted. Passing `--show-all` on the cmd line will now ensure that `show_all=True` gets passed to the kwargs of the Renderer's constructor. I also fixed the behavior of the base Render's constructor when `show_all=True`. This together *appears* to fix the bug pointed out in #223. @joerick Can you please test this PR out when you have a sec and let me know if that part also seems fixed to you?