### PR TITLE
session: show full command line using psutil

### DIFF
--- a/pyinstrument/profiler.py
+++ b/pyinstrument/profiler.py
@@ -152,12 +152,16 @@ class Profiler:
 
         cpu_time = process_time() - self._active_session.start_process_time
 
+        import psutil
+
+        cmdline = " ".join(psutil.Process().cmdline())
+
         session = Session(
             frame_records=self._active_session.frame_records,
             start_time=self._active_session.start_time,
             duration=time.time() - self._active_session.start_time,
             sample_count=len(self._active_session.frame_records),
-            program=" ".join(sys.argv),
+            program=cmdline,
             start_call_stack=self._active_session.start_call_stack,
             cpu_time=cpu_time,
         )

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
     author_email="joerick@mac.com",
     url="https://github.com/joerick/pyinstrument",
     keywords=["profiling", "profile", "profiler", "cpu", "time", "sampling"],
-    install_requires=[],
+    install_requires=["psutil"],
     extras_require={"jupyter": ["ipython"]},
     include_package_data=True,
     python_requires=">=3.7",


### PR DESCRIPTION
What do you think of this @joerick ? This does require `psutils`, but has the advantage of working well on all Unix/Win platforms.

Addresses #241.

```console
$ pyinstrument -m mpi4py t.py --myargs
Program: /Users/mdiener/Work/emirge/miniforge3/envs/ceesd/bin/python3.11 /Users/mdiener/Work/emirge/miniforge3/envs/ceesd/bin/pyinstrument -m mpi4py t.py --myargs