### PR TITLE
Stop built-in code showing as 'None' in traces

### DIFF
--- a/pyinstrument/frame.py
+++ b/pyinstrument/frame.py
@@ -204,6 +204,7 @@ class Frame:
     def code_position_short(self) -> str | None:
         if self.file_path_short and self.line_no:
             return "%s:%i" % (self.file_path_short, self.line_no)
+        return self.file_path_short
 
     _children: list[Frame]
     attributes: dict[str, float]


### PR DESCRIPTION
Fixes #252.

The issue here was a simple coding error, `self.line_no` was `0` so it was falling back as you said @mattip. I decided to keep the if as it was, though, since a line_no of 0 is still invalid, line numbers start at 1, but it will fallback to just the file_path_short, if it's available.
