### PR TITLE
Fix erroneous [group frames hidden] appearing in the output sometimes

### DIFF
--- a/examples/tbhide_demo.py
+++ b/examples/tbhide_demo.py
@@ -1,0 +1,25 @@
+import time
+
+
+def D():
+    time.sleep(0.7)
+
+
+def C():
+    __tracebackhide__ = True
+    time.sleep(0.1)
+    D()
+
+
+def B():
+    __tracebackhide__ = True
+    time.sleep(0.1)
+    C()
+
+
+def A():
+    time.sleep(0.1)
+    B()
+
+
+A()

--- a/pyinstrument/frame.py
+++ b/pyinstrument/frame.py
@@ -361,13 +361,17 @@ class FrameGroup:
     def frames(self) -> Sequence[Frame]:
         return tuple(self._frames)
 
-    # pylint: disable=W0212
     def add_frame(self, frame: Frame):
         if frame.group:
-            frame.group._frames.remove(frame)
+            frame.group.remove_frame(frame)
 
         self._frames.append(frame)
         frame.group = self
+
+    def remove_frame(self, frame: Frame):
+        assert frame.group is self
+        self._frames.remove(frame)
+        frame.group = None
 
     @property
     def exit_frames(self):

--- a/pyinstrument/renderers/console.py
+++ b/pyinstrument/renderers/console.py
@@ -212,10 +212,10 @@ class ConsoleRenderer(FrameRenderer):
             processors.remove_tracebackhide,
             processors.merge_consecutive_self_time,
             processors.aggregate_repeated_calls,
-            processors.group_library_frames_processor,
             processors.remove_unnecessary_self_time_nodes,
             processors.remove_irrelevant_nodes,
             processors.remove_first_pyinstrument_frames_processor,
+            processors.group_library_frames_processor,
         ]
 
     class colors_enabled:

--- a/pyinstrument/renderers/html.py
+++ b/pyinstrument/renderers/html.py
@@ -96,8 +96,8 @@ class HTMLRenderer(FrameRenderer):
             processors.remove_tracebackhide,
             processors.merge_consecutive_self_time,
             processors.aggregate_repeated_calls,
-            processors.group_library_frames_processor,
             processors.remove_unnecessary_self_time_nodes,
             processors.remove_irrelevant_nodes,
             processors.remove_first_pyinstrument_frames_processor,
+            processors.group_library_frames_processor,
         ]

--- a/pyinstrument/renderers/jsonrenderer.py
+++ b/pyinstrument/renderers/jsonrenderer.py
@@ -80,8 +80,8 @@ class JSONRenderer(FrameRenderer):
             processors.remove_tracebackhide,
             processors.merge_consecutive_self_time,
             processors.aggregate_repeated_calls,
-            processors.group_library_frames_processor,
             processors.remove_unnecessary_self_time_nodes,
             processors.remove_irrelevant_nodes,
             processors.remove_first_pyinstrument_frames_processor,
+            processors.group_library_frames_processor,
         ]

--- a/pyinstrument/renderers/pstatsrenderer.py
+++ b/pyinstrument/renderers/pstatsrenderer.py
@@ -90,7 +90,6 @@ class PstatsRenderer(FrameRenderer):
             processors.remove_tracebackhide,
             processors.merge_consecutive_self_time,
             processors.aggregate_repeated_calls,
-            processors.group_library_frames_processor,
             processors.remove_unnecessary_self_time_nodes,
             processors.remove_irrelevant_nodes,
             processors.remove_first_pyinstrument_frames_processor,

--- a/pyinstrument/renderers/speedscope.py
+++ b/pyinstrument/renderers/speedscope.py
@@ -236,7 +236,6 @@ class SpeedscopeRenderer(FrameRenderer):
             processors.remove_importlib,
             processors.remove_tracebackhide,
             processors.merge_consecutive_self_time,
-            processors.group_library_frames_processor,
             processors.remove_unnecessary_self_time_nodes,
             processors.remove_irrelevant_nodes,
             processors.remove_first_pyinstrument_frames_processor,


### PR DESCRIPTION
As seen in #233, we sometimes get strange output like

```
  _     ._   __/__   _ _  _  _ _/_   Recorded: 19:04:16  Samples:  5
 /_//_/// /_\ / //_// / //_'/ //     Duration: 1.021     CPU time: 0.002
/   _/                      v4.4.0

Program: /tmp/profilet.py

1.019 <module>  profilet.py:1
└─ 1.019 A  profilet.py:16
   ├─ 0.704 D  profilet.py:3
   │  └─ 0.704 sleep  None
   │        [2 frames hidden]  ..
   └─ 0.315 sleep  None
         [2 frames hidden]  ..

```
The [2 frames hidden] appear to be children of the built-in sleep function, which isn't correct. 

This bug appeared because frames can be added to groups and then removed, so sometimes the renderer gets to the sleep frame and sees that as the first frame in a group, so it shows the removed frames as children of that. 

Two solutions - fix the book keeping of the group membership, and also defer the calculation of group membership until after frames have been fully manipulated.
