### PR TITLE
Reset sys.argv after running child script/module

### DIFF
--- a/pyinstrument/__main__.py
+++ b/pyinstrument/__main__.py
@@ -294,11 +294,11 @@ def main():
                 # when called with '-m', search the cwd for that module
                 sys.path[0] = os.path.abspath(".")
 
-            sys.argv[:] = [options.module_name] + options.module_args
+            argv = [options.module_name] + options.module_args
             code = "run_module(modname, run_name='__main__', alter_sys=True)"
             globs = {"run_module": runpy.run_module, "modname": options.module_name}
         else:
-            sys.argv[:] = args
+            argv = args
             if options.from_path:
                 progname = shutil.which(args[0])
                 if progname is None:
@@ -322,10 +322,14 @@ def main():
 
         profiler.start()
 
+        old_argv = sys.argv.copy()
         try:
+            sys.argv[:] = argv
             exec(code, globs, None)
         except (SystemExit, KeyboardInterrupt):
             pass
+        finally:
+            sys.argv[:] = old_argv
 
         session = profiler.stop()
 

--- a/pyinstrument/magic/magic.py
+++ b/pyinstrument/magic/magic.py
@@ -137,7 +137,7 @@ class PyinstrumentMagic(Magics):
         )
         as_text = _active_profiler.output_text(timeline=args.timeline)
         # repr_html may be a bit fragile, but it's been stable for a while
-        display({"text/html": as_iframe._repr_html_(), "text/plain": as_text}, raw=True)
+        display({"text/html": as_iframe._repr_html_(), "text/plain": as_text}, raw=True)  # type: ignore
 
         assert not _active_profiler.is_running
         _active_profiler = None

--- a/test/test_cmdline.py
+++ b/test/test_cmdline.py
@@ -106,14 +106,14 @@ class TestCommandLine:
 
         process_pyi = subprocess.run(
             [*pyinstrument_invocation, "-m", "test_module", "arg1", "arg2"],
-            # stderr=subprocess.PIPE,
+            stderr=subprocess.PIPE,
             check=True,
             cwd=tmp_path,
             text=True,
         )
         process_native = subprocess.run(
             [sys.executable, "-m", "test_module", "arg1", "arg2"],
-            # stderr=subprocess.PIPE,
+            stderr=subprocess.PIPE,
             check=True,
             cwd=tmp_path,
             text=True,
@@ -121,6 +121,7 @@ class TestCommandLine:
 
         print("process_pyi.stderr", process_pyi.stderr)
         print("process_native.stderr", process_native.stderr)
+        assert process_native.stderr
         assert process_pyi.stderr == process_native.stderr
 
     def test_path_execution_details(self, pyinstrument_invocation, tmp_path: Path, monkeypatch):


### PR DESCRIPTION
Fixes #241.

Using `trace` as an example of a script that changes sys.argv:

Before:
```console
$ python -m pyinstrument -m trace --trace wikipedia_article_word_count.py
...
  _     ._   __/__   _ _  _  _ _/_   Recorded: 17:06:48  Samples:  476
 /_//_/// /_\ / //_// / //_'/ //     Duration: 0.819     CPU time: 0.437
/   _/                      v4.5.1

Program: trace

0.818 <module>  trace.py:1
...
```

After:

```console
$ python -m pyinstrument -m trace --trace wikipedia_article_word_count.py
...
  _     ._   __/__   _ _  _  _ _/_   Recorded: 17:08:07  Samples:  482
 /_//_/// /_\ / //_// / //_'/ //     Duration: 0.821     CPU time: 0.444
/   _/                      v4.5.1

Program: /Users/joerick/Projects/pyinstrument/pyinstrument/__main__.py -m trace --trace wikipedia_article_word_count.py

0.821 <module>  trace.py:1
...
```

aside: Note this doesn't change pyinstrument's way of passing sys.argv to children. The behaviour is that all of 

- `python script.py arg1 arg2`
- `python -m script.py arg1 arg2`
- `pyinstrument script.py arg1 arg2`

and

- `python -m module arg1 arg2`
- `python -m pyinstrument -m module arg1 arg2`
- `pyinstrument -m module arg1 arg2`
 
look the same from the child's perspective. That's verified in the test https://github.com/joerick/pyinstrument/blob/af87938d8647676dd185ecf6913ec5c30e225825/test/test_cmdline.py#L81
.

That test was faulty as written, I've also fixed that in this PR.
