### PR TITLE
make tracebackhide nodes hidden in html renderer

### DIFF
--- a/pyinstrument/processors.py
+++ b/pyinstrument/processors.py
@@ -128,6 +128,8 @@ def group_library_frames_processor(frame: Frame | None, options: ProcessorOption
             return False
         if should_hide:
             return True
+        if frame.has_tracebackhide:
+            return True
 
         return not frame.is_application_code
 

--- a/pyinstrument/renderers/base.py
+++ b/pyinstrument/renderers/base.py
@@ -93,7 +93,8 @@ class FrameRenderer(Renderer):
                 # processors.remove_first_pyinstrument_frames_processor,
                 #    (still hide the outer pyinstrument calling frames)
             ):
-                self.processors.remove(p)
+                if p in self.processors:
+                    self.processors.remove(p)
         if timeline:
             self.processors.remove(processors.aggregate_repeated_calls)
 

--- a/pyinstrument/renderers/html.py
+++ b/pyinstrument/renderers/html.py
@@ -93,7 +93,6 @@ class HTMLRenderer(FrameRenderer):
     def default_processors(self) -> ProcessorList:
         return [
             processors.remove_importlib,
-            processors.remove_tracebackhide,
             processors.merge_consecutive_self_time,
             processors.aggregate_repeated_calls,
             processors.remove_unnecessary_self_time_nodes,


### PR DESCRIPTION
Continuation of #190 and #211, #217, #223. There was a comment about
> We also suggest including a way to expand hidden nodes in HTML format.

that was not addressed.

This implements keeping tracebackhile nodes by:
- removing the `processors.remove_tracebackhide` on the html renderer
- add a check for hiding tracebackhide nodes in the `should_be_hidden` function

This is enough to change the output of the test in #223 

```
python -m pyinstrument -r html -o /tmp/throw_away.html /tmp/test_tracbackhidden.py
```
to (where the "hidden" nodes are expanded)
![Screenshot from 2023-08-06 12-40-35](https://github.com/joerick/pyinstrument/assets/823911/18be8a6b-2b25-40f9-803d-b55081ca22c0)

The tui output is unchanged:
```
$ python -m pyinstrument /tmp/test_tracbackhidden.py 

  _     ._   __/__   _ _  _  _ _/_   Recorded: 12:42:10  Samples:  4
 /_//_/// /_\ / //_// / //_'/ //     Duration: 1.002     CPU time: 0.001
/   _/                      v4.5.1

Program: /home/matti/oss/pyinstrument/pyinstrument/__main__.py /tmp/test_tracbackhidden.py

1.001 <module>  test_tracbackhidden.py:1
└─ 1.001 A  test_tracbackhidden.py:16
   ├─ 0.700 D  test_tracbackhidden.py:3
   │  └─ 0.700 sleep  <built-in>
   └─ 0.301 sleep  <built-in>

To view this report with different options, run:
    pyinstrument --load-prev 2023-08-06T12-42-10 [options]
```
