### PR TITLE
Add method to write directly to html file

### DIFF
--- a/docs/guide.md
+++ b/docs/guide.md
@@ -294,8 +294,7 @@ def auto_profile(request):
     profiler.stop()
     PROFILE_ROOT.mkdir(exist_ok=True)
     results_file = PROFILE_ROOT / f"{request.node.name}.html"
-    with open(results_file, "w", encoding="utf-8") as f_html:
-        f_html.write(profiler.output_html())
+    profiler.write_html(results_file)
 ```
 
 This will generate a HTML file for each test node in your test suite inside

--- a/metrics/interrupt.py
+++ b/metrics/interrupt.py
@@ -21,5 +21,4 @@ p.stop()
 
 print(p.output_text())
 
-with open("ioerror_out.html", "w") as f:
-    f.write(p.output_html())
+p.write_html("ioerror_out.html")

--- a/metrics/overflow.py
+++ b/metrics/overflow.py
@@ -21,5 +21,4 @@ p.stop()
 
 print(p.output_text())
 
-with open("overflow_out.html", "w") as f:
-    f.write(p.output_html())
+p.write_html("overflow_out.html")

--- a/metrics/overhead.py
+++ b/metrics/overhead.py
@@ -51,8 +51,7 @@ profiler.stop()
 # pyinstrument_timeline_timings = test_func()
 # profiler.stop()
 
-with open("out.html", "w") as f:
-    f.write(profiler.output_html())
+profiler.write_html("out.html")
 
 print(profiler.output_text(unicode=True, color=True))
 

--- a/pyinstrument/profiler.py
+++ b/pyinstrument/profiler.py
@@ -2,10 +2,10 @@ from __future__ import annotations
 
 import inspect
 import os
-from pathlib import Path
 import sys
 import time
 import types
+from pathlib import Path
 from time import process_time
 from typing import IO, Any
 
@@ -308,7 +308,7 @@ class Profiler:
 
     def write_html(self, path: str | os.PathLike[str], timeline: bool = False):
         """
-        Return the profile output as HTML, as rendered by :class:`HTMLRenderer`
+        Writes the profile output as HTML to a file, as rendered by :class:`HTMLRenderer`
         """
         file = Path(path)
         file.write_text(self.output(renderer=renderers.HTMLRenderer(timeline=timeline)))

--- a/pyinstrument/profiler.py
+++ b/pyinstrument/profiler.py
@@ -311,7 +311,10 @@ class Profiler:
         Writes the profile output as HTML to a file, as rendered by :class:`HTMLRenderer`
         """
         file = Path(path)
-        file.write_text(self.output(renderer=renderers.HTMLRenderer(timeline=timeline)))
+        file.write_text(
+            self.output(renderer=renderers.HTMLRenderer(timeline=timeline)),
+            encoding="utf-8",
+        )
 
     def open_in_browser(self, timeline: bool = False):
         """

--- a/pyinstrument/profiler.py
+++ b/pyinstrument/profiler.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import inspect
+import os
+from pathlib import Path
 import sys
 import time
 import types
@@ -303,6 +305,13 @@ class Profiler:
         Return the profile output as HTML, as rendered by :class:`HTMLRenderer`
         """
         return self.output(renderer=renderers.HTMLRenderer(timeline=timeline))
+
+    def write_html(self, path: str | os.PathLike[str], timeline: bool = False):
+        """
+        Return the profile output as HTML, as rendered by :class:`HTMLRenderer`
+        """
+        file = Path(path)
+        file.write_text(self.output(renderer=renderers.HTMLRenderer(timeline=timeline)))
 
     def open_in_browser(self, timeline: bool = False):
         """


### PR DESCRIPTION
Hello! Thanks for writing pyinstrument - I use it frequently, and absolutely love the html representation of the output!

This PR introduces a method `Profiler.write_html` in order to write `output_html` straight to a html file. It replaces the following pattern, which I use frequently:

```python
with Profiler() as profiler:
    # some_slow_code
Path("profile.html").write_text(profiler.output_html())
```

New pattern:

```python
with Profiler() as profiler:
    # some_slow_code
profiler.write_html("profile.html")
```

I'm unsure whether to add a test or not, since I would be basically testing `pathlib.Path.write_text`.