### PR TITLE
Add option to show total time including children in flat profiles

### DIFF
--- a/pyinstrument/renderers/console.py
+++ b/pyinstrument/renderers/console.py
@@ -26,6 +26,7 @@ class ConsoleRenderer(FrameRenderer):
         color: bool = False,
         flat: bool = False,
         time: LiteralStr["seconds", "percent_of_total"] = "seconds",
+        flat_time: LiteralStr["self", "total"] = "self",
         **kwargs: Any,
     ) -> None:
         """
@@ -33,6 +34,7 @@ class ConsoleRenderer(FrameRenderer):
         :param color: Enable color support, using ANSI color sequences.
         :param flat: Display a flat profile instead of a call graph.
         :param time: How to display the duration of each frame - ``'seconds'`` or ``'percent_of_total'``
+        :param flat_time: Show ``'self'`` time or ``'total'`` time (including children) in flat profile.
         """
         super().__init__(**kwargs)
 
@@ -40,6 +42,7 @@ class ConsoleRenderer(FrameRenderer):
         self.color = color
         self.flat = flat
         self.time = time
+        self.flat_time = flat_time
 
         if self.flat and self.timeline:
             raise Renderer.MisconfigurationError("Cannot use timeline and flat options together.")
@@ -131,7 +134,8 @@ class ConsoleRenderer(FrameRenderer):
     def render_frame_flat(self, frame: Frame) -> str:
         def walk(frame: Frame):
             frame_id_to_time[frame.identifier] = (
-                frame_id_to_time.get(frame.identifier, 0) + frame.total_self_time
+                frame_id_to_time.get(frame.identifier, 0) 
+                + frame.total_self_time if self.flat_time == "self" else frame.time
             )
 
             frame_id_to_frame[frame.identifier] = frame

--- a/test/test_renderers.py
+++ b/test/test_renderers.py
@@ -85,3 +85,9 @@ def test_show_all_doesnt_crash(
 ):
     renderer = frame_renderer_class(show_all=True)
     renderer.render(profiler_session)
+
+
+@pytest.mark.parametrize("flat_time", ["self", "total"])
+def test_console_renderer_flat_doesnt_crash(profiler_session, flat_time):
+    renderer = renderers.ConsoleRenderer(flat=True, flat_time=flat_time)
+    renderer.render(profiler_session)


### PR DESCRIPTION
Adds a literal string argument `flat_time` to `ConsoleRenderer` which can be used to set frame time type displayed (and used as sort key) in flat profiles - `"self"` for total self time, excluding child frames (the default, equivalent to current behaviour) and `"total"` for total time, including child frames. 

I find being able to view a flat list sorted by total time useful in some situations, but it does result in the less intutitive behaviour that the sum of the times shown no longer bears any relation to total run time. 

Rather than a string argument could alternatively use a boolean flag if preferred or change name of options.