### PR TITLE
Add flat argument to print to Profiler.print()

### DIFF
--- a/pyinstrument/profiler.py
+++ b/pyinstrument/profiler.py
@@ -258,8 +258,9 @@ class Profiler:
         color: bool | None = None,
         show_all: bool = False,
         timeline: bool = False,
+        flat: bool = False,
     ):
-        """print(file=sys.stdout, *, unicode=None, color=None, show_all=False, timeline=False)
+        """print(file=sys.stdout, *, unicode=None, color=None, show_all=False, timeline=False, flat=False)
 
         Print the captured profile to the console.
 
@@ -268,6 +269,7 @@ class Profiler:
         :param color: Override ANSI color support detection.
         :param show_all: Sets the ``show_all`` parameter on the renderer.
         :param timeline: Sets the ``timeline`` parameter on the renderer.
+        :param flat: Sets the ``flat`` parameter on the renderer.
         """
         if unicode is None:
             unicode = file_supports_unicode(file)
@@ -280,6 +282,7 @@ class Profiler:
                 color=color,
                 show_all=show_all,
                 timeline=timeline,
+                flat=flat,
             ),
             file=file,
         )
@@ -290,13 +293,14 @@ class Profiler:
         color: bool = False,
         show_all: bool = False,
         timeline: bool = False,
+        flat: bool = False,
     ) -> str:
         """
         Return the profile output as text, as rendered by :class:`ConsoleRenderer`
         """
         return self.output(
             renderer=renderers.ConsoleRenderer(
-                unicode=unicode, color=color, show_all=show_all, timeline=timeline
+                unicode=unicode, color=color, show_all=show_all, timeline=timeline, flat=flat
             )
         )
 


### PR DESCRIPTION
Currently flat can only be enabled via command line:
```
pyinstrument -p flat myscript.py
```
Add the flat argument to the `Profiler.print` method so it can be used via the python API.