### PR TITLE
Use slightly more recent IPython API.

### DIFF
--- a/pyinstrument/magic/magic.py
+++ b/pyinstrument/magic/magic.py
@@ -35,7 +35,7 @@ def _get_active_profiler():
 class PyinstrumentMagic(Magics):
     def __init__(self, shell):
         super().__init__(shell)
-        if IPython.version_info < (8, 15):
+        if IPython.version_info < (8, 15):  # type: ignore
             from ._utils import PrePostAstTransformer
 
             # This will leak _get_active_profiler into the users space until we can magle it
@@ -45,7 +45,7 @@ class PyinstrumentMagic(Magics):
             post = parse("\n_get_active_profiler().stop()")
             self._transformer = PrePostAstTransformer(pre, post)
         else:
-            from IPython.core.magics.ast_mod import ReplaceCodeTransformer
+            from IPython.core.magics.ast_mod import ReplaceCodeTransformer  # type: ignore
 
             self._transformer = ReplaceCodeTransformer.from_string(
                 dedent(


### PR DESCRIPTION
The new ast transformer are a bit more flexible instead of just appending/prepending some code and allow full Python constructs.

- you can use ``__code__`` for where the original code should go, and ``__ret__``
- by default it can also mangle all names that start with `___` (3 underscore), if you need some more hygienic templating. The names are still leaked in global namespace but with invalid python indentifiers names starting with `mangle-` (where `-` is invalid in an identifier).

This allow us to later clean the namespace manually in the magic.

And this also allwo us to also return the original value from the cell, I don't know if this is something desirable, but I added it nonetheless.