### PR TITLE
Allow non-vendored deps to be used

### DIFF
--- a/pyinstrument/__main__.py
+++ b/pyinstrument/__main__.py
@@ -20,7 +20,16 @@ from pyinstrument.util import (
     file_supports_unicode,
     object_with_import_path,
 )
-from pyinstrument.vendor import appdirs, keypath
+
+try:
+    from pyinstrument.vendor import appdirs
+except ImportError:
+    import appdirs
+
+try:
+    from pyinstrument.vendor import keypath
+except ImportError:
+    import keypath
 
 # pyright: strict
 

--- a/pyinstrument/util.py
+++ b/pyinstrument/util.py
@@ -5,7 +5,10 @@ import sys
 import warnings
 from typing import IO, Any, AnyStr, Callable
 
-from pyinstrument.vendor.decorator import decorator
+try:
+    from pyinstrument.vendor.decorator import decorator
+except ImportError:
+    from decorator import decorator
 
 
 def object_with_import_path(import_path: str) -> Any:


### PR DESCRIPTION
Distributions will want to get rid of the vendored dependencies and use the system versions. Modify the imports to try the bundled copy first, and then fall back to the system one. This keeps behaviour unchanged by default, but allows easy de-vendoring by simply removing the vendored copy from source.