### PR TITLE
test: do not compare sys.path in test executions

### DIFF
--- a/test/test_cmdline.py
+++ b/test/test_cmdline.py
@@ -14,7 +14,6 @@ EXECUTION_DETAILS_SCRIPT = f"""
 import sys, os
 print('__name__', __name__, file=sys.stderr)
 print('sys.argv', sys.argv, file=sys.stderr)
-print('sys.path', sys.path, file=sys.stderr)
 print('sys.executable', os.path.realpath(sys.executable), file=sys.stderr)
 print('os.getcwd()', os.getcwd(), file=sys.stderr)
 """.strip()


### PR DESCRIPTION
That test is fragile and fails in various ways, depending on how the tests are invoked. Instead assume that if the program is started correctly, $PYTHONPATH was set appropriately.

For example:
```
___ TestCommandLine.test_module_execution_details[pyinstrument_invocation0] ____ ...
E       AssertionError: assert '__name__ __m...n_details_0\n' == '__name__ __m...n_details_0\n'
E           __name__ __main__
E           sys.argv ['/tmp/pytest-of-mockbuild/pytest-1/test_module_execution_details_0/test_module/__main__.py', 'arg1', 'arg2']
E         - sys.path ['/tmp/pytest-of-mockbuild/pytest-1/test_module_execution_details_0',
                      '/builddir/build/BUILD/pyinstrument-4.6.2-build/BUILDROOT/usr/lib64/python3.12/site-packages',
                      '/builddir/build/BUILD/pyinstrument-4.6.2-build/BUILDROOT/usr/lib/python3.12/site-packages',
                      '/usr/lib64/python312.zip', '/usr/lib64/python3.12', '/usr/lib64/python3.12/lib-dynload',
                      '/usr/lib64/python3.12/site-packages', '/usr/lib/python3.12/site-packages']
```

With this patch, tests pass with the standard Fedora Linux invocation of pytest on the package installed in a temporary installation directory.