### PR TITLE
Fix #331 - prevent a crash when a cls or self variable is del'd

### DIFF
--- a/test/low_level/test_frame_info.py
+++ b/test/low_level/test_frame_info.py
@@ -7,24 +7,39 @@ from pyinstrument.low_level import stat_profile_python
 
 
 class AClass:
-    def get_frame_info_for_a_method(self, getter_function):
+    def get_frame_info_for_a_method(self, getter_function, del_local):
+        if del_local:
+            del self
         frame = inspect.currentframe()
         assert frame
         return getter_function(frame)
 
-    def get_frame_info_with_cell_variable(self, getter_function):
-        frame = inspect.currentframe()
-        assert frame
-
+    def get_frame_info_with_cell_variable(self, getter_function, del_local):
         def an_inner_function():
             # reference self to make it a cell variable
             if self:
                 pass
 
+        if del_local:
+            del self
+        frame = inspect.currentframe()
+        assert frame
+
         return getter_function(frame)
 
     @classmethod
-    def get_frame_info_for_a_class_method(cls, getter_function):
+    def get_frame_info_for_a_class_method(cls, getter_function, del_local):
+        if del_local:
+            del cls
+        frame = inspect.currentframe()
+        assert frame
+        return getter_function(frame)
+
+    @classmethod
+    def get_frame_info_for_a_class_method_where_cls_is_reassigned(cls, getter_function, del_local):
+        cls = 1
+        if del_local:
+            del cls
         frame = inspect.currentframe()
         assert frame
         return getter_function(frame)
@@ -70,10 +85,12 @@ instance = AClass()
         instance.get_frame_info_for_a_method,
         AClass.get_frame_info_for_a_class_method,
         instance.get_frame_info_with_cell_variable,
+        AClass.get_frame_info_for_a_class_method_where_cls_is_reassigned,
     ],
 )
-def test_frame_info_with_classes(test_function):
-    c_frame_info = test_function(stat_profile_c.get_frame_info)
-    py_frame_info = test_function(stat_profile_python.get_frame_info)
+@pytest.mark.parametrize("del_local", [True, False])
+def test_frame_info_with_classes(test_function, del_local):
+    c_frame_info = test_function(stat_profile_c.get_frame_info, del_local=del_local)
+    py_frame_info = test_function(stat_profile_python.get_frame_info, del_local=del_local)
 
     assert c_frame_info == py_frame_info

--- a/test/low_level/test_frame_info.py
+++ b/test/low_level/test_frame_info.py
@@ -1,5 +1,7 @@
 import inspect
 
+import pytest
+
 from pyinstrument.low_level import stat_profile as stat_profile_c
 from pyinstrument.low_level import stat_profile_python
 
@@ -59,17 +61,19 @@ def test_frame_info_hide_false():
     assert stat_profile_c.get_frame_info(frame) == stat_profile_python.get_frame_info(frame)
 
 
-def test_frame_info_with_classes():
-    instance = AClass()
+instance = AClass()
 
-    test_functions = [
+
+@pytest.mark.parametrize(
+    "test_function",
+    [
         instance.get_frame_info_for_a_method,
         AClass.get_frame_info_for_a_class_method,
         instance.get_frame_info_with_cell_variable,
-    ]
+    ],
+)
+def test_frame_info_with_classes(test_function):
+    c_frame_info = test_function(stat_profile_c.get_frame_info)
+    py_frame_info = test_function(stat_profile_python.get_frame_info)
 
-    for test_function in test_functions:
-        c_frame_info = test_function(stat_profile_c.get_frame_info)
-        py_frame_info = test_function(stat_profile_python.get_frame_info)
-
-        assert c_frame_info == py_frame_info
+    assert c_frame_info == py_frame_info


### PR DESCRIPTION
Fixes an issue where a missing `self` or `cls` local can cause a crash in the profiler code.
