### PR TITLE
Draft: Share option definition between cli and magic. 

### DIFF
--- a/pyinstrument/__main__.py
+++ b/pyinstrument/__main__.py
@@ -24,58 +24,6 @@ from pyinstrument.vendor import appdirs, keypath
 
 # pyright: strict
 
-from collections import namedtuple
-
-Option = namedtuple(
-    "Option", "short, long, dest, action, metavar, default, help, callback, type".split(", ")
-)
-
-
-class ParserAdapter:
-    _options: list
-
-    def __init__(self, opt_parser, /):
-        self._opt_parser = opt_parser
-        self._options = []
-
-    def add_option(
-        self,
-        short,
-        long,
-        /,
-        action,
-        help,
-        dest=None,
-        metavar=None,
-        default=None,
-        callback=None,
-        type=None,
-    ):
-        self._options.append(
-            Option(
-                short,
-                long,
-                dest=dest,
-                action=action,
-                default=default,
-                help=help,
-                metavar=metavar,
-                callback=callback,
-                type=type,
-            )
-        )
-        return self._opt_parser.add_option(
-            short,
-            long,
-            dest=dest,
-            action=action,
-            default=default,
-            help=help,
-            metavar=metavar,
-            callback=callback,
-            type=type,
-        )
-
 
 def _define_options(parser: optparse.OptionParser) -> None:
     """
@@ -317,15 +265,12 @@ def main():
         v=pyinstrument.__version__,
         pyv=sys.version_info,
     )
-    _parser: Any = optparse.OptionParser(usage=usage, version=version_string)
-    _parser.allow_interspersed_args = False
+    parser: Any = optparse.OptionParser(usage=usage, version=version_string)
+    parser.allow_interspersed_args = False
 
-    parser = ParserAdapter(_parser)
 
     _define_options(parser)
     # parse the options
-
-    parser = _parser
 
     if not sys.argv[1:]:
         parser.print_help()

--- a/pyinstrument/__main__.py
+++ b/pyinstrument/__main__.py
@@ -24,6 +24,58 @@ from pyinstrument.vendor import appdirs, keypath
 
 # pyright: strict
 
+from collections import namedtuple
+
+Option = namedtuple(
+    "Option", "short, long, dest, action, metavar, default, help, callback, type".split(", ")
+)
+
+
+class ParserAdapter:
+    _options: list
+
+    def __init__(self, opt_parser, /):
+        self._opt_parser = opt_parser
+        self._options = []
+
+    def add_option(
+        self,
+        short,
+        long,
+        /,
+        action,
+        help,
+        dest=None,
+        metavar=None,
+        default=None,
+        callback=None,
+        type=None,
+    ):
+        self._options.append(
+            Option(
+                short,
+                long,
+                dest=dest,
+                action=action,
+                default=default,
+                help=help,
+                metavar=metavar,
+                callback=callback,
+                type=type,
+            )
+        )
+        return self._opt_parser.add_option(
+            short,
+            long,
+            dest=dest,
+            action=action,
+            default=default,
+            help=help,
+            metavar=metavar,
+            callback=callback,
+            type=type,
+        )
+
 
 def _define_options(parser: optparse.OptionParser) -> None:
     """
@@ -53,6 +105,7 @@ def _define_options(parser: optparse.OptionParser) -> None:
         setattr(parser.values, option.dest, ValueWithRemainingArgs(value, remaining_arguments))
 
     parser.add_option(
+        "",
         "--load",
         dest="load",
         action="store",
@@ -264,11 +317,15 @@ def main():
         v=pyinstrument.__version__,
         pyv=sys.version_info,
     )
-    parser: Any = optparse.OptionParser(usage=usage, version=version_string)
-    parser.allow_interspersed_args = False
+    _parser: Any = optparse.OptionParser(usage=usage, version=version_string)
+    _parser.allow_interspersed_args = False
+
+    parser = ParserAdapter(_parser)
 
     _define_options(parser)
     # parse the options
+
+    parser = _parser
 
     if not sys.argv[1:]:
         parser.print_help()

--- a/pyinstrument/__main__.py
+++ b/pyinstrument/__main__.py
@@ -25,15 +25,13 @@ from pyinstrument.vendor import appdirs, keypath
 # pyright: strict
 
 
-def main():
-    usage = "usage: pyinstrument [options] scriptfile [arg] ..."
-    version_string = "pyinstrument {v}, on Python {pyv[0]}.{pyv[1]}.{pyv[2]}".format(
-        v=pyinstrument.__version__,
-        pyv=sys.version_info,
-    )
-    parser: Any = optparse.OptionParser(usage=usage, version=version_string)
-    parser.allow_interspersed_args = False
+def _define_options(parser: optparse.OptionParser) -> None:
+    """
+    Utility function to define parser options.
 
+    The goal in the end is to reuse this with the IPython magic to avoid redefining all
+    options twice.
+    """
     def store_and_consume_remaining(
         option: optparse.Option, opt: str, value: str, parser: optparse.OptionParser
     ):
@@ -259,6 +257,17 @@ def main():
         ),
     )
 
+
+def main():
+    usage = "usage: pyinstrument [options] scriptfile [arg] ..."
+    version_string = "pyinstrument {v}, on Python {pyv[0]}.{pyv[1]}.{pyv[2]}".format(
+        v=pyinstrument.__version__,
+        pyv=sys.version_info,
+    )
+    parser: Any = optparse.OptionParser(usage=usage, version=version_string)
+    parser.allow_interspersed_args = False
+
+    _define_options(parser)
     # parse the options
 
     if not sys.argv[1:]:


### PR DESCRIPTION
There is some request in #324 to have the same options (when possible) between the magic and the CLI. 

I'm looking into defining those options only once, and refactoring main/magic to not repeat the options handling. 

I'm tryin to be the least invasive as possible.

I'm not yet looking for deep review, but mostly letting you know I'm working on this, and maybe cursory validation that the approach is ok (or not), or wether you prefer a more thourough refactor, or simply me redefining the options twice in the `__main__` and the magic.