### PR TITLE
Export renderers from `pyinstrument.renderers`

### DIFF
--- a/pyinstrument/renderers/__init__.py
+++ b/pyinstrument/renderers/__init__.py
@@ -5,3 +5,14 @@ from pyinstrument.renderers.jsonrenderer import JSONRenderer
 from pyinstrument.renderers.pstatsrenderer import PstatsRenderer
 from pyinstrument.renderers.session import SessionRenderer
 from pyinstrument.renderers.speedscope import SpeedscopeRenderer
+
+__all__ = [
+    "ConsoleRenderer",
+    "FrameRenderer",
+    "HTMLRenderer",
+    "JSONRenderer",
+    "PstatsRenderer",
+    "Renderer",
+    "SessionRenderer",
+    "SpeedscopeRenderer",
+]


### PR DESCRIPTION
Type checkers don't like it when you use symbols that are not exported in that module. Putting the renderers in `__all__` will export them here so imports like this one pass mypy:

```
from pyinstrument.renderers import HTMLRenderer
```

Currently one must specify the specific module that owns the renderer to import it.

```
from pyinstrument.renderers.html import HTMLRenderer
```