### PR TITLE
⚡️ Speed up method `Frame.self_check` by 48%

### DIFF
--- a/pyinstrument/frame.py
+++ b/pyinstrument/frame.py
@@ -317,18 +317,22 @@ class Frame:
         Checks that the frame is valid.
         """
         if self.identifier in SYNTHETIC_LEAF_IDENTIFIERS:
-            assert len(self._children) == 0
-            # leaf frames have time that isn't attributable to their
-            # children, so we don't check that.
+            assert (
+                not self._children
+            )  # `len(self._children) == 0` is equivalent to `not self._children`
             return
 
-        calculated_time = sum(child.time for child in self.children) + self.absorbed_time
+        children = self.children  # Access the property once to avoid repetitive lookups
+        calculated_time = self.absorbed_time
+        for child in children:
+            calculated_time += child.time
+
         assert math.isclose(
             calculated_time, self.time
-        ), f"Frame time mismatch, should be {calculated_time}, was {self.time}, {self.children}"
+        ), f"Frame time mismatch, should be {calculated_time}, was {self.time}, {children}"
 
         if recursive:
-            for child in self.children:
+            for child in children:
                 child.self_check(recursive=True)
 
     def __repr__(self):


### PR DESCRIPTION
### 📄 48% (0.48x) speedup for ***`Frame.self_check` in `pyinstrument/frame.py`***

⏱️ Runtime :   **`122 microseconds`**  **→** **`82.6 microseconds`** (best of `30` runs)

📝 Explanation and details

This optimization is faster since it removed repeated attribute look ups. This should especially matter since it is a recursive function.

### Optimization Details.


✅ **Correctness verification report:**


| Test                        | Status            |
| --------------------------- | ----------------- |
| ⚙️ Existing Unit Tests | ✅ **15 Passed** |
| 🌀 Generated Regression Tests | ✅ **12 Passed** |
| ⏪ Replay Tests | 🔘 **None Found** |
| 🔎 Concolic Coverage Tests | ✅ **2 Passed** |
|📊 Tests Coverage       | 100.0% |
<details>
<summary>⚙️ Existing Unit Tests Details</summary>

```python
- test_processors.py
```

</details>

<details>
<summary>🌀 Generated Regression Tests Details</summary>

```python
from __future__ import annotations

import math
from typing import Sequence

# imports
import pytest  # used for our unit tests
from pyinstrument.frame import Frame
from pyinstrument.frame_info import frame_info_get_identifier

# Mock identifiers for testing
AWAIT_FRAME_IDENTIFIER = "await_frame"
SELF_TIME_FRAME_IDENTIFIER = "self_time_frame"
OUT_OF_CONTEXT_FRAME_IDENTIFIER = "out_of_context_frame"

# function to test
SYNTHETIC_LEAF_IDENTIFIERS = frozenset(
    [
        AWAIT_FRAME_IDENTIFIER,
        SELF_TIME_FRAME_IDENTIFIER,
        OUT_OF_CONTEXT_FRAME_IDENTIFIER,
    ]
)

# unit tests

def test_single_frame_no_children_zero_time():
    frame = Frame(identifier_or_frame_info="frame1", time=0)
    frame.self_check()  # Should pass without assertion error






def test_nested_frames_incorrect_time():
    child = Frame(identifier_or_frame_info="child1", time=5)
    parent = Frame(identifier_or_frame_info="parent1", children=[child], time=4)  # Incorrect time
    grandparent = Frame(identifier_or_frame_info="grandparent1", children=[parent], time=5)
    with pytest.raises(AssertionError):
        grandparent.self_check()  # Should raise an assertion error

def test_empty_frame():
    frame = Frame(identifier_or_frame_info="", time=0)
    frame.self_check()  # Should pass without assertion error




def test_invalid_identifier():
    frame = Frame(identifier_or_frame_info="invalid_identifier", time=0)
    frame.self_check()  # Should pass without assertion error


def test_absorbed_time_no_children():
    frame = Frame(identifier_or_frame_info="frame1", time=5)
    frame.absorbed_time = 5
    frame.self_check()  # Should pass without assertion error



from __future__ import annotations

import math
from typing import Sequence

# imports
import pytest  # used for our unit tests
from pyinstrument.frame import Frame
from pyinstrument.frame_info import frame_info_get_identifier

# Mocking the identifiers for the purpose of testing
AWAIT_FRAME_IDENTIFIER = "await_frame"
SELF_TIME_FRAME_IDENTIFIER = "self_time_frame"
OUT_OF_CONTEXT_FRAME_IDENTIFIER = "out_of_context_frame"

SYNTHETIC_LEAF_IDENTIFIERS = frozenset(
    [
        AWAIT_FRAME_IDENTIFIER,
        SELF_TIME_FRAME_IDENTIFIER,
        OUT_OF_CONTEXT_FRAME_IDENTIFIER,
    ]
)

# unit tests

def test_single_frame_no_children_zero_time():
    frame = Frame(identifier_or_frame_info="frame1", time=0.0)
    frame.self_check()





def test_empty_children_list():
    frame = Frame(identifier_or_frame_info="frame", children=[], time=0.0)
    frame.self_check()



def test_mismatched_time():
    child1 = Frame(identifier_or_frame_info="child1", time=2.0)
    child2 = Frame(identifier_or_frame_info="child2", time=3.0)
    frame = Frame(identifier_or_frame_info="parent", children=[child1, child2], time=4.0)
    with pytest.raises(AssertionError):
        frame.self_check()




def test_no_time_recorded():
    child1 = Frame(identifier_or_frame_info="child1", time=0.0)
    child2 = Frame(identifier_or_frame_info="child2", time=0.0)
    frame = Frame(identifier_or_frame_info="parent", children=[child1, child2], time=0.0)
    frame.self_check()





from pyinstrument.frame import Frame
import pytest

def test_Frame_self_check():
    with pytest.raises(AssertionError, match='Frame\\ time\\ mismatch,\\ should\\ be\\ 0\\.0,\\ was\\ inf,\\ \\(\\)'):
        Frame.self_check(Frame(identifier_or_frame_info='', children=None, time=float("inf"), context=None), recursive=False)

def test_Frame_self_check_2():
    assert Frame.self_check(Frame(identifier_or_frame_info='', children=(Frame(identifier_or_frame_info='\x00\x02', children=(Frame(identifier_or_frame_info='', children=(), time=0.0, context=None)), time=0.0, context=None)), time=0.0, context=None), recursive=True) == None

def test_Frame_self_check_3():
    assert Frame.self_check(Frame(identifier_or_frame_info='', children=None, time=0.0, context=None), recursive=False) == None
```

</details>


Optimized with [codeflash.ai](https://codeflash.ai)