### PR TITLE
Fix %%pyinstrument magic to handle KeyboardInterrupt

### DIFF
--- a/pyinstrument/magic/magic.py
+++ b/pyinstrument/magic/magic.py
@@ -2,12 +2,12 @@ from __future__ import annotations
 
 import asyncio
 import html
+import sys
 import threading
 import urllib.parse
 from ast import parse
-from textwrap import dedent
-import sys
 from signal import SIGINT
+from textwrap import dedent
 
 import IPython
 from IPython import get_ipython  # type: ignore

--- a/pyinstrument/magic/magic.py
+++ b/pyinstrument/magic/magic.py
@@ -6,6 +6,8 @@ import threading
 import urllib.parse
 from ast import parse
 from textwrap import dedent
+import sys
+from signal import SIGINT
 
 import IPython
 from IPython import get_ipython  # type: ignore
@@ -240,6 +242,9 @@ class PyinstrumentMagic(Magics):
                 raw=True,
             )
             return
+
+        if isinstance(cell_result.error_in_exec, KeyboardInterrupt):
+            sys.exit(SIGINT)
 
         html_config = compute_render_options(
             args, renderer_class=HTMLRenderer, unicode_support=True, color_support=True

--- a/pyinstrument/magic/magic.py
+++ b/pyinstrument/magic/magic.py
@@ -305,7 +305,7 @@ class PyinstrumentMagic(Magics):
             asyncio.set_event_loop(loop)
             coro = ip.run_cell_async(code)
             future = asyncio.run_coroutine_threadsafe(coro, loop)
-            return future.result().result
+            return future.result()
         finally:
             loop.call_soon_threadsafe(loop.stop)
             asyncio.set_event_loop(old_loop)

--- a/pyinstrument/magic/magic.py
+++ b/pyinstrument/magic/magic.py
@@ -243,7 +243,11 @@ class PyinstrumentMagic(Magics):
             )
             return
 
+        # If a KeyboardInterrupt occurred during the magic execution,
+        # send a SIGINT signal to prevent further executions.
         if isinstance(cell_result.error_in_exec, KeyboardInterrupt):
+            # The traceback is already shown during the cell execution above, so we
+            # don't re-raise the exception.
             sys.exit(SIGINT)
 
         html_config = compute_render_options(

--- a/pyinstrument/magic/magic.py
+++ b/pyinstrument/magic/magic.py
@@ -2,11 +2,9 @@ from __future__ import annotations
 
 import asyncio
 import html
-import sys
 import threading
 import urllib.parse
 from ast import parse
-from signal import SIGINT
 from textwrap import dedent
 
 import IPython
@@ -248,7 +246,7 @@ class PyinstrumentMagic(Magics):
             return
 
         # If a KeyboardInterrupt occurred during the magic execution,
-        # send a SIGINT signal to prevent further executions.
+        # raise an exception to prevent further executions.
         if isinstance(cell_result.error_in_exec, KeyboardInterrupt):
             # The traceback is already shown during the cell execution above, so we
             # don't re-raise the exception directly.

--- a/test/test_ipython_magic.py
+++ b/test/test_ipython_magic.py
@@ -1,6 +1,9 @@
 from test.fake_time_util import fake_time
-
+import signal
 import pytest
+import sys
+from time import sleep
+from threading import Thread
 
 # note: IPython should be imported within each test. Importing it in our tests
 # seems to cause problems with subsequent tests.
@@ -76,6 +79,33 @@ def test_magic_no_variable_expansion(ip, capsys):
     assert "hello {len('world')}" in captured.out
     assert "hello 5" not in captured.out
 
+@pytest.mark.ipythonmagic
+def test_pyinstrument_handles_sigint(ip):
+    exit_called_with_sigint = False
+
+    # Mock sys.exit
+    original_exit = sys.exit
+
+    def mock_exit(code=0):
+        nonlocal exit_called_with_sigint
+        if code == signal.SIGINT:
+            exit_called_with_sigint = True
+            raise KeyboardInterrupt("Mocked SIGINT exit")
+        original_exit(code)
+
+    sys.exit = mock_exit
+
+    try:
+        with pytest.raises(KeyboardInterrupt):
+            thread = Thread(target=_interrupt_after_1s)
+            thread.start()
+            ip.run_cell_magic("pyinstrument", "", "from time import sleep; sleep(2)")
+            thread.join()
+
+        assert exit_called_with_sigint, "%%pyinstrument did not call sys.exit(SIGINT) when interrupted"
+
+    finally:
+        sys.exit = original_exit
 
 # Utils #
 
@@ -86,6 +116,9 @@ def session_ip():
 
     yield start_ipython()
 
+def _interrupt_after_1s():
+    sleep(1)
+    signal.raise_signal(signal.SIGINT)
 
 @pytest.fixture(scope="function")
 def ip(session_ip):

--- a/test/test_ipython_magic.py
+++ b/test/test_ipython_magic.py
@@ -1,9 +1,10 @@
-from test.fake_time_util import fake_time
 import signal
-import pytest
 import sys
-from time import sleep
+from test.fake_time_util import fake_time
 from threading import Thread
+from time import sleep
+
+import pytest
 
 # note: IPython should be imported within each test. Importing it in our tests
 # seems to cause problems with subsequent tests.
@@ -79,6 +80,7 @@ def test_magic_no_variable_expansion(ip, capsys):
     assert "hello {len('world')}" in captured.out
     assert "hello 5" not in captured.out
 
+
 @pytest.mark.ipythonmagic
 def test_pyinstrument_handles_sigint(ip):
     exit_called_with_sigint = False
@@ -102,10 +104,13 @@ def test_pyinstrument_handles_sigint(ip):
             ip.run_cell_magic("pyinstrument", "", "from time import sleep; sleep(2)")
             thread.join()
 
-        assert exit_called_with_sigint, "%%pyinstrument did not call sys.exit(SIGINT) when interrupted"
+        assert (
+            exit_called_with_sigint
+        ), "%%pyinstrument did not call sys.exit(SIGINT) when interrupted"
 
     finally:
         sys.exit = original_exit
+
 
 # Utils #
 
@@ -116,9 +121,11 @@ def session_ip():
 
     yield start_ipython()
 
+
 def _interrupt_after_1s():
     sleep(1)
     signal.raise_signal(signal.SIGINT)
+
 
 @pytest.fixture(scope="function")
 def ip(session_ip):

--- a/test/test_ipython_magic.py
+++ b/test/test_ipython_magic.py
@@ -1,5 +1,4 @@
 import signal
-import sys
 from test.fake_time_util import fake_time
 from threading import Thread
 from time import sleep

--- a/test/test_ipython_magic.py
+++ b/test/test_ipython_magic.py
@@ -1,4 +1,5 @@
 import signal
+import textwrap
 from test.fake_time_util import fake_time
 from threading import Thread
 from time import sleep
@@ -94,6 +95,26 @@ def test_pyinstrument_handles_interrupt_silently(ip, capsys):
     # nothing should have hit stderr
     _, err = capsys.readouterr()
     assert err.strip() == ""
+
+
+@pytest.mark.ipythonmagic
+def test_async_cell_with_pyinstrument(ip, capsys):
+    ip.run_cell_magic(
+        "pyinstrument",
+        line="--async_mode=enabled",
+        cell=textwrap.dedent(
+            """
+            import asyncio
+            async def function_a():
+                await asyncio.sleep(0.1)
+                return 42
+            a = await function_a()
+            print("a:", a)
+            """
+        ),
+    )
+    stdout, stderr = capsys.readouterr()
+    assert "a: 42" in stdout
 
 
 # Utils #


### PR DESCRIPTION
## Fixes https://github.com/joerick/pyinstrument/issues/371

This PR ensures that the `%%pyinstrument` cell magic properly handles `KeyboardInterrupt`.

Previously, when a user interrupted execution (e.g., via Ctrl-C), the signal was not handled correctly, allowing subsequent cells to run unintentionally.

Now, the magic exits with `SIGINT` using `sys.exit(SIGINT)`, preventing further execution and aligning behavior with standard cell execution.

Logs on keyboard interrupt
```
---------------------------------------------------------------------------
KeyboardInterrupt                         Traceback (most recent call last)
Cell In[6], line 1
----> 1 sleep(10)

KeyboardInterrupt: 
An exception has occurred, use %tb to see the full traceback.

SystemExit: 2
```