### PR TITLE
Update profiler.py: fix mypy valid-type error

### DIFF
--- a/pyinstrument/profiler.py
+++ b/pyinstrument/profiler.py
@@ -7,20 +7,15 @@ import time
 import types
 from pathlib import Path
 from time import process_time
-from typing import TYPE_CHECKING, IO, Any
+from typing import IO, Any
 
 from pyinstrument import renderers
 from pyinstrument.frame import AWAIT_FRAME_IDENTIFIER, OUT_OF_CONTEXT_FRAME_IDENTIFIER
 from pyinstrument.renderers.console import FlatTimeMode
 from pyinstrument.session import Session
 from pyinstrument.stack_sampler import AsyncState, StackSampler, build_call_stack, get_stack_sampler
-from pyinstrument.typing import LiteralStr
+from pyinstrument.typing import LiteralStr, TypeAlias
 from pyinstrument.util import file_supports_color, file_supports_unicode
-
-if TYPE_CHECKING:
-    from typing_extensions import TypeAlias
-else:
-    TypeAlias = Any
 
 # pyright: strict
 

--- a/pyinstrument/profiler.py
+++ b/pyinstrument/profiler.py
@@ -7,8 +7,7 @@ import time
 import types
 from pathlib import Path
 from time import process_time
-from typing import IO, Any
-from typing_extensions import TypeAlias
+from typing import TYPE_CHECKING, IO, Any
 
 from pyinstrument import renderers
 from pyinstrument.frame import AWAIT_FRAME_IDENTIFIER, OUT_OF_CONTEXT_FRAME_IDENTIFIER
@@ -17,6 +16,11 @@ from pyinstrument.session import Session
 from pyinstrument.stack_sampler import AsyncState, StackSampler, build_call_stack, get_stack_sampler
 from pyinstrument.typing import LiteralStr
 from pyinstrument.util import file_supports_color, file_supports_unicode
+
+if TYPE_CHECKING:
+    from typing_extensions import TypeAlias
+else:
+    TypeAlias = Any
 
 # pyright: strict
 

--- a/pyinstrument/profiler.py
+++ b/pyinstrument/profiler.py
@@ -8,6 +8,7 @@ import types
 from pathlib import Path
 from time import process_time
 from typing import IO, Any
+from typing_extensions import TypeAlias
 
 from pyinstrument import renderers
 from pyinstrument.frame import AWAIT_FRAME_IDENTIFIER, OUT_OF_CONTEXT_FRAME_IDENTIFIER
@@ -39,7 +40,7 @@ class ActiveProfilerSession:
         self.interval = interval
 
 
-AsyncMode = LiteralStr["enabled", "disabled", "strict"]
+AsyncMode: TypeAlias = LiteralStr["enabled", "disabled", "strict"]
 
 
 class Profiler:

--- a/pyinstrument/typing.py
+++ b/pyinstrument/typing.py
@@ -2,11 +2,8 @@ import os
 from typing import TYPE_CHECKING, Any, Union
 
 if TYPE_CHECKING:
-    import typing_extensions
-
-    LiteralStr = typing_extensions.Literal
-    assert_never = typing_extensions.assert_never
-    Unpack = typing_extensions.Unpack
+    from typing_extensions import Literal as LiteralStr
+    from typing_extensions import TypeAlias, Unpack, assert_never
 else:
     # a type, that when subscripted, returns `str`.
     class _LiteralStr:
@@ -19,8 +16,9 @@ else:
         raise ValueError(value)
 
     Unpack = Any
+    TypeAlias = Any
 
 
 PathOrStr = Union[str, "os.PathLike[str]"]
 
-__all__ = ["PathOrStr", "LiteralStr", "assert_never", "Unpack"]
+__all__ = ["PathOrStr", "LiteralStr", "assert_never", "Unpack", "TypeAlias"]


### PR DESCRIPTION
Mypy, a typechecker, complains when code using this library uses the exposed type AsyncMode, for reasons explained here https://github.com/python/mypy/issues/8674 and here https://mypy.readthedocs.io/en/stable/common_issues.html#variables-vs-type-aliases — this patch fixes that problem by adding a TypeAlias type annotation.

I'm not convinced this is valuable behavior on mypy's part, but I am using mypy, and pyinstrument, so, might as well comply with its wishes, to shut it up 🙂 