### PR TITLE
docs: mention that FastAPI profiling only works for async routes

### DIFF
--- a/docs/guide.md
+++ b/docs/guide.md
@@ -217,6 +217,11 @@ creates the html output and returns that instead of the actual response.
 To profile call stacks in FastAPI, you can write a middleware extension for
 pyinstrument.
 
+```{caution}
+Only `async` path operation functions are profiled with this approach. Routes that are defined without `async def` are executed in a separate execution thread, and therefore not profiled by this approach.
+See [issue #257](https://github.com/joerick/pyinstrument/issues/257) and [FastAPI Concurrency and async / await](https://fastapi.tiangolo.com/async/) for more information.
+```
+
 Create an async function and decorate with `app.middleware('http')` where
 app is the name of your FastAPI application instance.
 


### PR DESCRIPTION
As discussed in #257 , only async routes are profiled. This PR mentions it in the documentation and links to the issue for more information.