### PR TITLE
Fix a bug where mismatched start/stops can produce "call stack without an active session" errors

### DIFF
--- a/pyinstrument/profiler.py
+++ b/pyinstrument/profiler.py
@@ -145,6 +145,9 @@ class Profiler:
                     caller_frame.f_code.co_filename, caller_frame.f_lineno
                 )
 
+        if self.is_running:
+            raise ValueError("Profiler is already running.")
+
         try:
             self._active_session = ActiveProfilerSession(
                 start_time=time.time(),

--- a/pyinstrument/stack_sampler.py
+++ b/pyinstrument/stack_sampler.py
@@ -82,6 +82,10 @@ class StackSampler:
                 )
             active_profiler_context_var.set(target)
 
+        existing_subscriber = next((s for s in self.subscribers if s.target == target), None)
+        if existing_subscriber is not None:
+            raise ValueError("This target is already subscribed to the stack sampler.")
+
         self.subscribers.append(
             StackSamplerSubscriber(
                 target=target,

--- a/test/test_profiler.py
+++ b/test/test_profiler.py
@@ -396,3 +396,12 @@ def test_profiler_convenience_methods_have_all_options_available(
         assert (
             method_parameter.annotation == parameter.annotation
         ), f"Parameter {name} has a different annotation in Profiler.{profiler_method_name}. {parameter}"
+
+
+def test_profiler_raises_on_double_subscribe():
+    profiler = Profiler(async_mode="disabled")
+    profiler.start()
+    with pytest.raises(ValueError) as e:
+        profiler.start()
+    assert "Profiler is already running" in str(e.value)
+    profiler.stop()

--- a/test/test_stack_sampler.py
+++ b/test/test_stack_sampler.py
@@ -128,3 +128,16 @@ def test_multiple_contexts():
     assert sys.getprofile() is None
 
     assert len(sampler.subscribers) == 0
+
+
+def test_same_callback_twice_error():
+    sampler = stack_sampler.get_stack_sampler()
+
+    counter = SampleCounter()
+
+    sampler.subscribe(counter.sample, desired_interval=0.001, use_async_context=False)
+
+    with pytest.raises(ValueError):
+        sampler.subscribe(counter.sample, desired_interval=0.001, use_async_context=False)
+
+    sampler.unsubscribe(counter.sample)


### PR DESCRIPTION
Fix #405
