### PR TITLE
Add possibility to customize description using CLI option

### DIFF
--- a/pyinstrument/__main__.py
+++ b/pyinstrument/__main__.py
@@ -391,8 +391,16 @@ def main():
             use_timing_thread=options.use_timing_thread,
         )
 
-        # TODO: better message in case of key error?
-        target_description = options.target_description.format(args=" ".join(argv))
+        try:
+            target_description = options.target_description.format(args=" ".join(argv))
+        except KeyError as e:
+            parser.error(f"Unknown placeholder {e.args[0]!r} in --target-description")
+            # explicitly add exit() so that pyright doesn't complain, even
+            # though parser.error already exits with error code 2
+            exit(2)
+        except IndexError as e:
+            parser.error(f"Empty placeholder in --target-description")
+            exit(2)
 
         profiler.start(target_description=target_description)
 

--- a/test/test_cmdline.py
+++ b/test/test_cmdline.py
@@ -307,6 +307,38 @@ class TestCommandLine:
 
         assert f"foobar {busy_wait_py}" in str(output)
 
+    def test_target_description_format_errors(self, pyinstrument_invocation, tmp_path: Path):
+        busy_wait_py = tmp_path / "busy_wait.py"
+        busy_wait_py.write_text(BUSY_WAIT_SCRIPT)
+
+        result = subprocess.run(
+            [
+                *pyinstrument_invocation,
+                "--target-description",
+                "''{foo}'",
+                str(busy_wait_py),
+            ],
+            text=True,
+            stderr=subprocess.PIPE,
+        )
+
+        assert f"Unknown placeholder 'foo'" in str(result.stderr)
+        assert result.returncode == 2
+
+        result = subprocess.run(
+            [
+                *pyinstrument_invocation,
+                "--target-description",
+                "''{}'",
+                str(busy_wait_py),
+            ],
+            text=True,
+            stderr=subprocess.PIPE,
+        )
+
+        assert f"Empty placeholder" in str(result.stderr)
+        assert result.returncode == 2
+
     def test_binary_output(self, pyinstrument_invocation, tmp_path: Path):
         busy_wait_py = tmp_path / "busy_wait.py"
         busy_wait_py.write_text(BUSY_WAIT_SCRIPT)


### PR DESCRIPTION
Closes #395.

I didn't include the "Program:" part in the formatted placeholder, so I called it `{args}` instead of `{program}`. I also added some basic error checking to the formatting so if there is a typo, you get a more helpful message than a mysterious KeyError.

Please let me know if there is something in the argument naming that could be improved or if some additional documentation needs to be updated etc.