### PR TITLE
Debugging Windows CI test failures

### DIFF
--- a/test/test_cmdline.py
+++ b/test/test_cmdline.py
@@ -302,10 +302,11 @@ class TestCommandLine:
                 "--target-description",
                 "'foobar {args}'",
                 str(busy_wait_py),
-            ]
+            ],
+            text=True,
         )
 
-        assert f"foobar {busy_wait_py}" in str(output)
+        assert f"foobar {busy_wait_py}" in output
 
     def test_target_description_format_errors(self, pyinstrument_invocation, tmp_path: Path):
         busy_wait_py = tmp_path / "busy_wait.py"


### PR DESCRIPTION
Two `test_target_description_format` cases have been failing on Windows CI since aa58942.

`subprocess.check_output` returns bytes; `str(bytes)` renders the repr, which doubles backslashes — so on Windows paths the substring check never matches. Pass `text=True` and drop the `str()` wrap.