### PR TITLE
Remove unused dead code

### DIFF
--- a/pyinstrument/frame_info.py
+++ b/pyinstrument/frame_info.py
@@ -3,11 +3,9 @@ from typing import List, Tuple
 # pyright: strict
 
 
-IDENTIFIER_SEP = "\x00"
 ATTRIBUTES_SEP = "\x01"
 
 ATTRIBUTE_MARKER_CLASS_NAME = "c"
-ATTRIBUTE_MARKER_LINE_NUMBER = "l"
 ATTRIBUTE_MARKER_TRACEBACKHIDE = "h"
 
 

--- a/pyinstrument/low_level/stat_profile_python.py
+++ b/pyinstrument/low_level/stat_profile_python.py
@@ -4,7 +4,7 @@ import contextvars
 import sys
 import timeit
 import types
-from typing import Any, Callable, List, Optional, Type
+from typing import Any, Callable, List, Optional
 
 from pyinstrument.low_level.pyi_timing_thread_python import (
     pyi_timing_thread_get_time,

--- a/pyinstrument/magic/magic.py
+++ b/pyinstrument/magic/magic.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import asyncio
 import html
 import threading
-import urllib.parse
 from ast import parse
 from textwrap import dedent
 
@@ -262,10 +261,6 @@ class PyinstrumentMagic(Magics):
             # install our silent handler
             ip.set_custom_exc((InterruptSilently,), _silent_exception_handler)
             raise InterruptSilently()
-
-        html_config = compute_render_options(
-            args, renderer_class=HTMLRenderer, unicode_support=True, color_support=True
-        )
 
         text_config = compute_render_options(
             args, renderer_class=HTMLRenderer, unicode_support=True, color_support=True

--- a/pyinstrument/middleware.py
+++ b/pyinstrument/middleware.py
@@ -1,4 +1,3 @@
-import io
 import os
 import sys
 import time

--- a/pyinstrument/session.py
+++ b/pyinstrument/session.py
@@ -14,12 +14,6 @@ from pyinstrument.typing import PathOrStr
 # pyright: strict
 
 
-ASSERTION_MESSAGE = (
-    "Please raise an issue at https://github.com/joerick/pyinstrument/issues and "
-    "let me know how you caused this error!"
-)
-
-
 class Session:
     def __init__(
         self,

--- a/pyinstrument/util.py
+++ b/pyinstrument/util.py
@@ -36,22 +36,6 @@ def deprecated(func: Callable[..., Any], *args: Any, **kwargs: Any) -> Any:
     return func(*args, **kwargs)
 
 
-def deprecated_option(option_name: str, message: str = "") -> Any:
-    """Marks an option as deprecated."""
-
-    def caller(func, *args, **kwargs):
-        if option_name in kwargs:
-            warnings.warn(
-                f"{option_name} is deprecated. {message}",
-                DeprecationWarning,
-                stacklevel=3,
-            )
-
-        return func(*args, **kwargs)
-
-    return decorator(caller)
-
-
 def file_supports_color(file_obj: IO[AnyStr]) -> bool:
     """
     Returns True if the running system's terminal supports color.


### PR DESCRIPTION
Hello.. This pr removes dead code confirmed via static analysis + LLM verification:

  - `util.py`. Remove `deprecated_option()`.. has zero callers
  - `frame_info.py`. Remove `IDENTIFIER_SEP` and `ATTRIBUTE_MARKER_LINE_NUMBER` constants, never referenced anywhere else outside `frame_info.py`
  - `session.py`. Remove `ASSERTION_MESSAGE` constant.. no references also
  - `low_level/stat_profile_python.py`. Remove unused `Type` import
  - `magic/magic.py`. Remove unused `urllib.parse` import and dead `html_config` assignment
  - `middleware.py`. Remove unused `io` import                                                   
                                                            
Dead code identified using [Skylos](https://github.com/duriantaco/skylos) and confirmed by manual verification