### PR TITLE
Add types to the Profiler context manager

### DIFF
--- a/pyinstrument/profiler.py
+++ b/pyinstrument/profiler.py
@@ -228,7 +228,7 @@ class Profiler:
 
         self._last_session = None
 
-    def __enter__(self):
+    def __enter__(self) -> Profiler:
         """
         Context manager support.
 
@@ -246,7 +246,12 @@ class Profiler:
         self.start(caller_frame=inspect.currentframe().f_back)  # type: ignore
         return self
 
-    def __exit__(self, *args: Any):
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_value: BaseException | None,
+        traceback: types.TracebackType | None,
+    ) -> None:
         self.stop()
 
     # pylint: disable=W0613


### PR DESCRIPTION
Hiya!

I love using this pattern:
```python
from pyinstrument import Profiler

with Profiler() as profile:
    ...
    profile.write_html()
```

The `ty` type checker requires explicit type signatures to determine the type of `profile`, and that's what I've added in this PR. Without it, I do not get type completion of the `write_html` method.

Strictly, the return type of `__enter__` should probably be `Self`, but that was introduced in Python 3.11. Support exists for python down to 3.8 (pyinstrument has `python_requires>=3.8`) in the `typing_extensions` library, but I see that that package isn't a default dependency (it's in the `typing` extra). But I don't think anyone is subclassing the `Profiler` class, so I think that `Profiler` is absolutely fine.

Here's proof that this PR fixes the issue, using ty version `0.0.56 (3078f9fa2 2026-07-01)`. `profile` goes from being Unknown to being of type `Profiler`.
<img width="559" height="391" alt="image" src="https://github.com/user-attachments/assets/98323126-c063-40a7-83a3-cefaa8cf804f" />

