### PR TITLE
Fix pre-commit hook, switch to prek for speed

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,7 @@ on:
     branches: [ main ]
 
 jobs:
-  pre-commit:
+  prek:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
@@ -17,9 +17,7 @@ jobs:
     - name: Install Python deps
       run: |
         pip install -r requirements-dev.txt
-    - uses: pre-commit/action@v3.0.1
-      with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+    - uses: j178/prek-action@v2
 
   test:
     runs-on: ${{ matrix.os }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -56,6 +56,9 @@ repos:
         entry: bin/build_js_bundle.py --force
         files: html_renderer/.*
         language: node
+        # package.json lives in html_renderer; this ensures Node is provisioned for the hook.
+        additional_dependencies:
+        -   npm
         pass_filenames: false
 
 -   repo: https://github.com/asottile/pyupgrade

--- a/README.md
+++ b/README.md
@@ -571,7 +571,7 @@ To setup a dev environment:
     . env/bin/activate
     pip install --upgrade pip
     pip install -r requirements-dev.txt
-    pre-commit install --install-hooks
+    prek install --install-hooks
 
 To get some sample output:
 
@@ -583,9 +583,9 @@ To run the tests:
 
 To run linting checks locally:
 
-    pre-commit run --all-files
+    prek run --all-files
 
-Some of the pre-commit checks, like `isort` or `black`, will auto-fix
+Some of the checks, like `isort` or `black`, will auto-fix
 the problems they find. So if the above command returns an error, try
 running it again, it might succeed the second time :)
 
@@ -593,12 +593,12 @@ Running all the checks can be slow, so you can also run checks
 individually, e.g., to format source code that fails `isort` or `black`
 checks:
 
-    pre-commit run --all-files isort
-    pre-commit run --all-files black
+    prek run --all-files isort
+    prek run --all-files black
 
 To diagnose why `pyright` checks are failing:
 
-    pre-commit run --all-files pyright
+    prek run --all-files pyright
 
 ### The HTML renderer Vue.js app
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,2 +1,1 @@
--e .[test,bin,docs,examples,types]
-prek
+-e .[test,bin,docs,examples,tools,types]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,1 +1,2 @@
 -e .[test,bin,docs,examples,types]
+prek

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,10 @@ setup(
         ],
         "bin": [
             "click",
+        ],
+        "tools": [
             "nox",
+            "prek",
         ],
         "docs": [
             "sphinx==7.4.7",


### PR DESCRIPTION
Use prek in GitHub Actions and local development. Keep the JS build hook
in a managed Node environment so contributors do not need Node installed
separately.
