### PR TITLE
fix: respect PYINSTRUMENT_SHOW_CALLBACK when PYINSTRUMENT_PROFILE_DIR is set

### DIFF
--- a/docs/guide.md
+++ b/docs/guide.md
@@ -179,6 +179,9 @@ def custom_show_pyinstrument(request):
 PYINSTRUMENT_SHOW_CALLBACK = "%s.custom_show_pyinstrument" % __name__
 ```
 
+This callback also applies when `PYINSTRUMENT_PROFILE_DIR` is set, so it can be
+used to select which requests get written to the profile directory.
+
 You can configure the profile output type using setting's variable `PYINSTRUMENT_PROFILE_DIR_RENDERER`.
 Default value is `pyinstrument.renderers.HTMLRenderer`. The supported renderers are
 `pyinstrument.renderers.JSONRenderer`, `pyinstrument.renderers.HTMLRenderer`,

--- a/pyinstrument/middleware.py
+++ b/pyinstrument/middleware.py
@@ -46,10 +46,10 @@ class ProfilerMiddleware(MiddlewareMixin):  # type: ignore
         else:
             show_pyinstrument = lambda request: True
 
-        if (
-            show_pyinstrument(request)
-            and getattr(settings, "PYINSTRUMENT_URL_ARGUMENT", "profile") in request.GET
-        ) or profile_dir:
+        if show_pyinstrument(request) and (
+            getattr(settings, "PYINSTRUMENT_URL_ARGUMENT", "profile") in request.GET
+            or profile_dir
+        ):
             interval: float = getattr(settings, "PYINSTRUMENT_INTERVAL", 0.001)
             profiler = Profiler(interval=interval)
             profiler.start()

--- a/pyinstrument/middleware.py
+++ b/pyinstrument/middleware.py
@@ -47,8 +47,7 @@ class ProfilerMiddleware(MiddlewareMixin):  # type: ignore
             show_pyinstrument = lambda request: True
 
         if show_pyinstrument(request) and (
-            getattr(settings, "PYINSTRUMENT_URL_ARGUMENT", "profile") in request.GET
-            or profile_dir
+            getattr(settings, "PYINSTRUMENT_URL_ARGUMENT", "profile") in request.GET or profile_dir
         ):
             interval: float = getattr(settings, "PYINSTRUMENT_INTERVAL", 0.001)
             profiler = Profiler(interval=interval)

--- a/test/test_django_middleware.py
+++ b/test/test_django_middleware.py
@@ -24,11 +24,11 @@ def stop_profiler(request):
         request.profiler.stop()
 
 
-def test_show_callback_is_respected_with_profile_dir():
+def test_show_callback_is_respected_with_profile_dir(tmp_path):
     from django.test import override_settings
 
     with override_settings(
-        PYINSTRUMENT_PROFILE_DIR="/tmp/pyinstrument-test-profiles",
+        PYINSTRUMENT_PROFILE_DIR=str(tmp_path),
         PYINSTRUMENT_SHOW_CALLBACK=lambda request: False,
     ):
         request = RequestFactory().get("/")
@@ -39,11 +39,11 @@ def test_show_callback_is_respected_with_profile_dir():
             stop_profiler(request)
 
 
-def test_profile_dir_still_profiles_when_callback_allows():
+def test_profile_dir_still_profiles_when_callback_allows(tmp_path):
     from django.test import override_settings
 
     with override_settings(
-        PYINSTRUMENT_PROFILE_DIR="/tmp/pyinstrument-test-profiles",
+        PYINSTRUMENT_PROFILE_DIR=str(tmp_path),
         PYINSTRUMENT_SHOW_CALLBACK=lambda request: True,
     ):
         request = RequestFactory().get("/")

--- a/test/test_django_middleware.py
+++ b/test/test_django_middleware.py
@@ -1,0 +1,54 @@
+import pytest
+
+django = pytest.importorskip("django")
+
+from django.conf import settings  # noqa: E402
+from django.test import RequestFactory  # noqa: E402
+
+
+@pytest.fixture(scope="module", autouse=True)
+def django_settings():
+    if not settings.configured:
+        settings.configure(DEBUG=True, ALLOWED_HOSTS=["*"])
+        django.setup()
+
+
+def make_middleware():
+    from pyinstrument.middleware import ProfilerMiddleware
+
+    return ProfilerMiddleware(lambda request: None)
+
+
+def stop_profiler(request):
+    if hasattr(request, "profiler"):
+        request.profiler.stop()
+
+
+def test_show_callback_is_respected_with_profile_dir():
+    from django.test import override_settings
+
+    with override_settings(
+        PYINSTRUMENT_PROFILE_DIR="/tmp/pyinstrument-test-profiles",
+        PYINSTRUMENT_SHOW_CALLBACK=lambda request: False,
+    ):
+        request = RequestFactory().get("/")
+        try:
+            make_middleware().process_request(request)
+            assert not hasattr(request, "profiler")
+        finally:
+            stop_profiler(request)
+
+
+def test_profile_dir_still_profiles_when_callback_allows():
+    from django.test import override_settings
+
+    with override_settings(
+        PYINSTRUMENT_PROFILE_DIR="/tmp/pyinstrument-test-profiles",
+        PYINSTRUMENT_SHOW_CALLBACK=lambda request: True,
+    ):
+        request = RequestFactory().get("/")
+        try:
+            make_middleware().process_request(request)
+            assert hasattr(request, "profiler")
+        finally:
+            stop_profiler(request)


### PR DESCRIPTION
Closes #342

The Django middleware's condition was `(show_pyinstrument(request) and url_argument in request.GET) or profile_dir`, so as soon as `PYINSTRUMENT_PROFILE_DIR` was set every request was profiled and `PYINSTRUMENT_SHOW_CALLBACK` was ignored. The callback now gates both branches, so it can be used to select which requests get written to the profile directory. Regression test fails on main (`assert not hasattr(request, "profiler")`) and passes with the fix.
